### PR TITLE
Add dependencies print for Quarkus added artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # quarkus-utilities
 Utilities used for experiments and testing with Quarkus
 
-##Existing utilities
+## Existing utilities
 
 ### diff-utils
 
-`create_colorful_diff.sh` utility to create  the colorfull diff between two files.
+- `create_colorful_diff.sh` utility to create  the colorful diff between two files.
+- Java program that prints dependencies of added artifacts \
+`mvn clean install exec:java -Dquarkus.maven.dir="path_to_dir" -Dquarkus.new-artifacts-list="added_artifacts.txt"`

--- a/diff-utils/.gitignore
+++ b/diff-utils/.gitignore
@@ -1,0 +1,16 @@
+.classpath
+.settings
+.project
+target
+.factorypath
+bin
+*.iml
+../.idea
+
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+release.properties
+impsort-maven-cache.properties

--- a/diff-utils/pom.xml
+++ b/diff-utils/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.quarkus.qe</groupId>
+    <artifactId>diff-utils</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <version.io.rest-assured>4.5.1</version.io.rest-assured>
+        <version.org.apache.maven.plugins.maven-surefire-plugin>2.21.0</version.org.apache.maven.plugins.maven-surefire-plugin>
+        <version.jboss.logging>3.4.2.Final</version.jboss.logging>
+        <version.jboss.logmanager>2.1.9.Final</version.jboss.logmanager>
+        <version.com.googlecode.grep4j>1.8.7</version.com.googlecode.grep4j>
+        <version.org.apache.maven.plugins>3.11.0</version.org.apache.maven.plugins>
+        <version.org.projectlombok.lombok>1.18.30</version.org.projectlombok.lombok>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>xml-path</artifactId>
+            <version>${version.io.rest-assured}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>${version.jboss.logging}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <version>${version.jboss.logmanager}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.grep4j</groupId>
+            <artifactId>grep4j</artifactId>
+            <version>${version.com.googlecode.grep4j}</version>
+        </dependency>
+        <!--  lombok is a dependency of grep4j, it needs newer version to be Java 17 compatible
+        https://stackoverflow.com/questions/66801256/java-lang-illegalaccesserror-class-lombok-javac-apt-lombokprocessor-cannot-acce -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${version.org.projectlombok.lombok}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <maven.home>${maven.home}</maven.home>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemPropertyVariables>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.org.apache.maven.plugins}</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>io.quarkus.qe.Main</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/diff-utils/src/main/java/io/quarkus/qe/AddedArtifactsPrint.java
+++ b/diff-utils/src/main/java/io/quarkus/qe/AddedArtifactsPrint.java
@@ -1,0 +1,116 @@
+package io.quarkus.qe;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import org.grep4j.core.model.Profile;
+import org.grep4j.core.model.ProfileBuilder;
+import org.grep4j.core.result.GrepResult;
+import org.grep4j.core.result.GrepResults;
+import org.jboss.logging.Logger;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.grep4j.core.Grep4j.grep;
+import static org.grep4j.core.Grep4j.constantExpression;
+import static org.grep4j.core.Grep4j.regularExpression;
+
+public class AddedArtifactsPrint {
+
+    private final String addedArtifactsListPath;
+    private static MavenRepo repo;
+    private static final char DEPENDENCY_INDEX_DELIMITER = '\t';
+    private static final String DEPENDENCY_INDEX_PATH = AddedArtifactsPrint.class.getProtectionDomain().getCodeSource().getLocation().getPath() + "quarkus-dependency-index.txt";
+    private static final Logger LOG = org.jboss.logging.Logger.getLogger(AddedArtifactsPrint.class);
+
+    public AddedArtifactsPrint() {
+        addedArtifactsListPath = Objects.requireNonNull(System.getProperty("quarkus.new-artifacts-list"),
+                "System property 'quarkus.new-artifacts-list' expected");
+        String mavenRepoDirStr = Objects.requireNonNull(System.getProperty("quarkus.maven.dir"),
+                "System property 'quarkus.maven.dir' expected");
+        repo = MavenRepo.at(Paths.get(mavenRepoDirStr).resolve("."));
+    }
+
+    public void printToFile() throws IOException {
+        String currentWorkingDir = System.getProperty("user.dir");
+
+        buildDependencyIndex();
+        Multimap<Coordinates, String> allCoordinates = HashMultimap.create();
+        try (Stream<Artifact> artifacts = repo.artifacts()) {
+            artifacts
+                    .filter(Artifact::isPom)
+                    .peek(artifact -> LOG.debug(String.valueOf(artifact)))
+                    .map(artifact -> artifact.asPom().versionedCoordinates())
+                    .forEach(coords -> allCoordinates.put(coords.withoutVersion(), coords.version()));
+        }
+
+        try (FileWriter fileWriter = new FileWriter(currentWorkingDir + "/added_artifacts_deps.txt")) {
+            PrintWriter printWriter = new PrintWriter(fileWriter);
+            allCoordinates.keySet()
+                    .forEach(coords -> {
+                        if (hasAddedArtifact(coords.toString())) {
+                            String version = allCoordinates.get(coords).toString();
+                            printWriter.printf("\nDependants for %s - %s :: ADDED \n(%s)\n",
+                                    coords, version, getDependentsInfo(coords));
+                        }
+                    });
+        }
+    }
+
+    private void buildDependencyIndex() throws IOException {
+        try (PrintWriter writer = new PrintWriter(DEPENDENCY_INDEX_PATH, StandardCharsets.UTF_8)) {
+            repo.artifacts()
+                    .filter(Artifact::isPom)
+                    .map(Artifact::asPom)
+                    .flatMap(this::getPomDependencyIndexEntries)
+                    .forEach(writer::println);
+        }
+    }
+
+    private Stream<String> getPomDependencyIndexEntries(Artifact.Pom pom) {
+        final VersionedCoordinates versionedCoordinates = pom.versionedCoordinates();
+        return pom.getDependenciesGav()
+                .map(dependency -> String.format("%s%s%s", versionedCoordinates, DEPENDENCY_INDEX_DELIMITER, dependency));
+    }
+
+    private String getDependentsInfo(Coordinates coordinates) {
+        final String dependents = grepDependencyIndex(String.format("%s:", coordinates));
+        return dependents.isEmpty() ? "no dependents found" : String.format("dependents: %s", dependents);
+    }
+
+    private String grepDependencyIndex(String pattern) {
+        final Profile indexFile = ProfileBuilder.newBuilder()
+                .name("POM file")
+                .filePath(DEPENDENCY_INDEX_PATH)
+                .onLocalhost()
+                .build();
+
+        final GrepResults grepResults = grep(constantExpression(DEPENDENCY_INDEX_DELIMITER + pattern), indexFile);
+
+        return grepResults.stream()
+                .map(GrepResult::getText)
+                .flatMap(Pattern.compile("\\R")::splitAsStream)
+                .map(line -> line.replace(String.valueOf(DEPENDENCY_INDEX_DELIMITER), " <- "))
+                .collect(Collectors.joining(", \n"));
+    }
+
+    private boolean hasAddedArtifact(String artifact) {
+        final Profile indexFile = ProfileBuilder.newBuilder()
+                .name("Added artifacts")
+                .filePath(addedArtifactsListPath)
+                .onLocalhost()
+                .build();
+
+        String pattern = String.format("^%s$", artifact);
+        final GrepResults grepResults = grep(regularExpression(pattern), indexFile);
+
+        return grepResults.totalLines() > 0;
+    }
+}

--- a/diff-utils/src/main/java/io/quarkus/qe/Artifact.java
+++ b/diff-utils/src/main/java/io/quarkus/qe/Artifact.java
@@ -1,0 +1,165 @@
+package io.quarkus.qe;
+
+import io.restassured.path.xml.XmlPath;
+import org.apache.commons.lang3.StringUtils;
+import org.grep4j.core.model.Profile;
+import org.grep4j.core.model.ProfileBuilder;
+import org.grep4j.core.result.GrepResult;
+import org.grep4j.core.result.GrepResults;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.grep4j.core.Grep4j.constantExpression;
+import static org.grep4j.core.Grep4j.grep;
+import static org.grep4j.core.fluent.Dictionary.option;
+import static org.grep4j.core.fluent.Dictionary.with;
+import static org.grep4j.core.options.Option.extraLinesAfter;
+
+public final class Artifact {
+    private final Path file;
+    private final String baseFileName;
+    private final Path rootDirectory; // only for toString
+
+    public Artifact(Path file, Path rootDirectory) {
+        this.file = file;
+        this.baseFileName = file.getFileName().toString();
+        this.rootDirectory = rootDirectory;
+    }
+
+    public Path file() {
+        return file;
+    }
+
+    public Path directory() {
+        return file.getParent();
+    }
+
+    public String baseFileName() {
+        return baseFileName;
+    }
+
+    public Path relativePath() {
+        return rootDirectory.relativize(file);
+    }
+
+    public String artifactIdInParentDirName() {
+        return file.getParent().getParent().getFileName().toString();
+    }
+
+    public String versionInParentDirName() {
+        return file.getParent().getFileName().toString();
+    }
+
+    public boolean isPom() {
+        return baseFileName.endsWith(".pom");
+    }
+
+    public Pom asPom() {
+        return new Pom();
+    }
+
+    @Override
+    public String toString() {
+        return "artifact " + rootDirectory.relativize(file);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof Artifact)) {
+            return false;
+        }
+
+        Artifact artifact = (Artifact) o;
+        return Objects.equals(file, artifact.file);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(file);
+    }
+
+    public final class Pom {
+        private static final String DEPENDENCY_TAG = "<dependency>";
+        private static final String DEPENDENCY_CLOSING_TAG = "</dependency>";
+        private static final String GROUP_ID_TAG = "<groupId>";
+        private static final String ARTIFACT_ID_TAG = "<artifactId>";
+        private static final String VERSION_TAG = "<version>";
+        private static final String CLOSING_TAG_START = "</";
+        private static final String EXCLUSIONS_TAG = "<exclusions>";
+
+        private Pom() {
+            if (!isPom()) {
+                throw new IllegalStateException("Not a POM: " + Artifact.this);
+            }
+        }
+
+        public VersionedCoordinates versionedCoordinates() {
+            XmlPath xml = XmlPath.from(file.toFile());
+            String artifactId = xml.getString("project.artifactId");
+            String groupId = xml.getString("project.groupId");
+            if (groupId == null || groupId.isEmpty()) {
+                groupId = xml.getString("project.parent.groupId");
+            }
+            String version = xml.getString("project.version");
+            if (version == null || version.isEmpty()) {
+                version = xml.getString("project.parent.version");
+            }
+
+            return new VersionedCoordinates(groupId, artifactId, version);
+        }
+
+        public Coordinates coordinates() {
+            return versionedCoordinates().withoutVersion();
+        }
+
+        public VersionedCoordinates parentVersionedCoordinates() {
+            XmlPath xml = XmlPath.from(file.toFile());
+            String artifactId = xml.getString("project.parent.artifactId");
+            String groupId = xml.getString("project.parent.groupId");
+            String version = xml.getString("project.parent.version");
+
+            return new VersionedCoordinates(groupId, artifactId, version);
+        }
+
+        public Coordinates parentCoordinates() {
+            return parentVersionedCoordinates().withoutVersion();
+        }
+
+        public Stream<String> getDependenciesGav() {
+            final Profile pomFile = ProfileBuilder.newBuilder()
+                    .name("POM file")
+                    .filePath(file.toString())
+                    .onLocalhost()
+                    .build();
+            final GrepResults grepResults = grep(
+                    constantExpression("<dependency>"),
+                    pomFile,
+                    with(option(extraLinesAfter(6))));
+            return grepResults.stream()
+                    .map(GrepResult::getText)
+                    .flatMap(this::extractDependenciesGav);
+        }
+
+        private Stream<String> extractDependenciesGav(String grepResult) {
+            final String[] dependencies = StringUtils.substringsBetween(grepResult, DEPENDENCY_TAG, DEPENDENCY_CLOSING_TAG);
+            if (dependencies == null) {
+                return Stream.empty();
+            }
+            return Arrays.stream(dependencies)
+                    .map(dep -> StringUtils.substringBefore(dep, EXCLUSIONS_TAG))
+                    .map(dep -> {
+                        final String groupId = StringUtils.substringBetween(dep, GROUP_ID_TAG, CLOSING_TAG_START);
+                        final String artifactId = StringUtils.substringBetween(dep, ARTIFACT_ID_TAG, CLOSING_TAG_START);
+                        final String version = StringUtils.substringBetween(dep, VERSION_TAG, CLOSING_TAG_START);
+                        return String.format("%s:%s:%s", groupId, artifactId, version == null ? "" : version);
+                    });
+        }
+    }
+}

--- a/diff-utils/src/main/java/io/quarkus/qe/Coordinates.java
+++ b/diff-utils/src/main/java/io/quarkus/qe/Coordinates.java
@@ -1,0 +1,54 @@
+package io.quarkus.qe;
+
+import java.util.Objects;
+
+public final class Coordinates {
+    private final String groupId;
+    private final String artifactId;
+
+    public Coordinates(String groupId, String artifactId) {
+        this.groupId = Objects.requireNonNull(groupId, "Group ID must be set");
+        this.artifactId = Objects.requireNonNull(artifactId, "Artifact ID must be set");
+    }
+
+    public static Coordinates parse(String coords) {
+        String[] parts = coords.split(":");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Expected 'groupId:artifactId': " + coords);
+        }
+
+        return new Coordinates(parts[0], parts[1]);
+    }
+
+    public String groupId() {
+        return groupId;
+    }
+
+    public String artifactId() {
+        return artifactId;
+    }
+
+    @Override
+    public String toString() {
+        return groupId + ":" + artifactId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof Coordinates)) {
+            return false;
+        }
+
+        Coordinates that = (Coordinates) o;
+        return Objects.equals(groupId, that.groupId) && Objects.equals(artifactId, that.artifactId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, artifactId);
+    }
+}

--- a/diff-utils/src/main/java/io/quarkus/qe/Main.java
+++ b/diff-utils/src/main/java/io/quarkus/qe/Main.java
@@ -1,0 +1,10 @@
+package io.quarkus.qe;
+
+import java.io.IOException;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        AddedArtifactsPrint addedArtifactsPrint = new AddedArtifactsPrint();
+        addedArtifactsPrint.printToFile();
+    }
+}

--- a/diff-utils/src/main/java/io/quarkus/qe/MavenRepo.java
+++ b/diff-utils/src/main/java/io/quarkus/qe/MavenRepo.java
@@ -1,0 +1,53 @@
+package io.quarkus.qe;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public final class MavenRepo {
+    private final Path rootDirectory;
+
+    private MavenRepo(Path rootDirectory) {
+        this.rootDirectory = rootDirectory;
+    }
+
+    public static MavenRepo at(Path rootDirectory) {
+        if (!Files.isDirectory(rootDirectory)) {
+            throw new IllegalArgumentException("Directory expected: " + rootDirectory);
+        }
+
+        return new MavenRepo(rootDirectory.toAbsolutePath().normalize());
+    }
+
+    public Stream<Artifact> artifacts() throws IOException {
+        return Files.walk(rootDirectory)
+                .filter(Files::isRegularFile)
+                .map(path -> new Artifact(path, rootDirectory));
+    }
+
+    @Override
+    public String toString() {
+        return "Maven repository " + rootDirectory;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof MavenRepo)) {
+            return false;
+        }
+
+        MavenRepo mavenRepo = (MavenRepo) o;
+        return Objects.equals(rootDirectory, mavenRepo.rootDirectory);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rootDirectory);
+    }
+}

--- a/diff-utils/src/main/java/io/quarkus/qe/VersionedCoordinates.java
+++ b/diff-utils/src/main/java/io/quarkus/qe/VersionedCoordinates.java
@@ -1,0 +1,53 @@
+package io.quarkus.qe;
+
+import java.util.Objects;
+
+public final class VersionedCoordinates {
+    private final Coordinates coordinates;
+    private final String version;
+
+    public VersionedCoordinates(String groupId, String artifactId, String version) {
+        this.coordinates = new Coordinates(groupId, artifactId);
+        this.version = Objects.requireNonNull(version, "Version must be set for " + groupId + ":" + artifactId);
+    }
+
+    public Coordinates withoutVersion() {
+        return coordinates;
+    }
+
+    public String groupId() {
+        return coordinates.groupId();
+    }
+
+    public String artifactId() {
+        return coordinates.artifactId();
+    }
+
+    public String version() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return coordinates + ":" + version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof VersionedCoordinates)) {
+            return false;
+        }
+
+        VersionedCoordinates that = (VersionedCoordinates) o;
+        return Objects.equals(coordinates, that.coordinates) && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(coordinates, version);
+    }
+}


### PR DESCRIPTION
This PR extends current RHBQ artifact diff job with dependencies print of added/new artifacts. This Java program will be used in Jenkins job later.
After running program `mvn clean install exec:java -Dquarkus.maven.dir="path_to_dir" -Dquarkus.new-artifacts-list="added_artifacts.txt"`, the result is saved to file added_artifacts_deps.txt