### PR TITLE
Add utility for creating diff between upstream and downstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,36 @@ Creates PDF with Quarkus extensions contain given dependency (quarkus-vertx, qua
 ### artifact-version-diff
 
 Create the report of different version between two Qaurkus version. This can be used for upstream vs RHBQ or upstream vs upstream.
+The utility clone Quarkus repository with specified tag and run `mvn versions:compare-dependencies` to create diff files used to generate report.
+It's possible only generate report, to check which artifact are different. Testing is useful when running automated check.
 
-- Preparation:
-  - `git clone https://github.com/quarkusio/quarkus.git`
-  - `git checkout <tag>` tag should be version which will be base for comparison e.g. 3.8.3
-  - `mvn versions:compare-dependencies -DremotePom=com.redhat.quarkus.platform:quarkus-bom:<version_to_compare> -Dmaven.repo.local="<path_to_local_repository>" -DreportOutputFile=<name_of_output_file>`
+To quickly generate diff between RHBQ and upstream you can use `prod_vs_upstream.sh` script. This script need two argument:
+
+1. RHBQ platform bom version (e.g. `3.8.3.redhat-00002`)
+2. Path to local maven repository
+
+Example usage of script `./prod_vs_upstream.sh 3.8.3.redhat-00002 ~/rh-quarkus-platform-3.8.3.GA-maven-repository/maven-repository`
+
+Or you can run it manually as described below.
+
 - Generation
-  - `mvn clean install exec:java -Dpath-to-quarkus-repository=<path_to_quarkus_repo> -Dversion-plugin.report-output-file=<name_of_output_file_from_version_plugin> -DskipTests`
+  - `mvn clean install exec:java -DskipTests -Dmaven.repo.local=<path_to_maven_local_repository> -Dquarkus.repo.tag=<tag_to_checkout> -Dquarkus.platform.bom=<platform_bom>`
+  - The `maven.repo.local` is optional
+  - The `quarkus.repo.tag` if source/base for comparing the versions. This needs to be valid tag in Quarkus git repository
+  - The `quarkus.platform.bom` needs to be in format `<groupID>:<artifactID>:version`
   - The diff is stored in `outputDiff.html` and `outputDiffDetailed.html` contains which extension or part of Quarkus are affected.
+  - Comparing with RHBQ example (version 3.8.3 vs 3.8.3.redhat-00002):
+    - `mvn clean install exec:java -DskipTests -Dmaven.repo.local=<path_to_maven_local_repository> -Dquarkus.platform.bom=com.redhat.quarkus.platform:quarkus-bom:3.8.3.redhat-00002 -Dquarkus.repo.tag=3.8.3`
+  - Comparing two upstream versions example (version 3.8.3 vs 3.8.4):
+    - `mvn clean install exec:java -DskipTests -Dquarkus.platform.bom=io.quarkus.platform:quarkus-bom:3.8.4 -Dquarkus.repo.tag=3.8.3`
 - Testing
   - There is possibility to test if there is some artifact which have different version
-  - `mvn clean test -Dpath-to-quarkus-repository=<path_to_quarkus_repo> -Dversion-plugin.report-output-file=<name_of_output_file_from_version_plugin> -Dquarkus-version=<base_version_of_quarkus>`
-  - `quarkus-version` property is optional if not set all different artifacts are treated as not allowed
+  - `mvn clean test -Dmaven.repo.local=<path_to_maven_local_repository> -Dquarkus.repo.tag=<tag_to_checkout> -Dquarkus.platform.bom=<platform_bom> -Dquarkus-version=<major_minor_quarkus_cersion>`
+  - The `maven.repo.local` is optional
+  - The `quarkus-version` is optional if not set all different artifacts are treated as not allowed
+  - The `quarkus.repo.tag` if source/base for comparing the versions. This needs to be valid tag in Quarkus git repository
+  - The `quarkus.platform.bom` needs to be in format `<groupID>:<artifactID>:version`
   - Example of `quarkus-version` usage `-Dquarkus-version=3.8` or just run with example `-Dquarkus-version=example`
-  - These allowed artifacts config file needs to be stored in `src/main/resources` and should have format of `<quarkus_version>_allowed_artifacts.yaml`, where `_allowed_artifacts.yaml` is must have to work.
+  - These allowed artifacts config file needs to be stored in `src/main/resources` and should have format of `<quarkus_version>_allowed_artifacts.yaml` (e.g `3.8_allowed_artifacts.yaml`), where `_allowed_artifacts.yaml` is must have to work.
+  - Testing with RHBQ example (version 3.8.3 vs 3.8.3.redhat-00002):
+    - `mvn clean test -Dmaven.repo.local=<path_to_maven_local_repository> -Dquarkus.platform.bom=com.redhat.quarkus.platform:quarkus-bom:3.8.3.redhat-00002 -Dquarkus.repo.tag=3.8.3`

--- a/README.md
+++ b/README.md
@@ -19,3 +19,21 @@ Creates PDF with Quarkus extensions contain given dependency (quarkus-vertx, qua
 - Usage:`get-extensions.sh DEPENDENCY_NAME [OUTPUT_FILE_NAME].pdf` 
 - Example: `./get-extensions.sh quarkus-vertx extensions-vertx.pdf`
 - Result will be written by default to the PDF document `Quarkus-extensions-with-*.pdf` or to the file with your custom name
+
+### artifact-version-diff
+
+Create the report of different version between two Qaurkus version. This can be used for upstream vs RHBQ or upstream vs upstream.
+
+- Preparation:
+  - `git clone https://github.com/quarkusio/quarkus.git`
+  - `git checkout <tag>` tag should be version which will be base for comparison e.g. 3.8.3
+  - `mvn versions:compare-dependencies -DremotePom=com.redhat.quarkus.platform:quarkus-bom:<version_to_compare> -Dmaven.repo.local="<path_to_local_repository>" -DreportOutputFile=<name_of_output_file>`
+- Generation
+  - `mvn clean install exec:java -Dpath-to-quarkus-repository=<path_to_quarkus_repo> -Dversion-plugin.report-output-file=<name_of_output_file_from_version_plugin> -DskipTests`
+  - The diff is stored in `outputDiff.html` and `outputDiffDetailed.html` contains which extension or part of Quarkus are affected.
+- Testing
+  - There is possibility to test if there is some artifact which have different version
+  - `mvn clean test -Dpath-to-quarkus-repository=<path_to_quarkus_repo> -Dversion-plugin.report-output-file=<name_of_output_file_from_version_plugin> -Dquarkus-version=<base_version_of_quarkus>`
+  - `quarkus-version` property is optional if not set all different artifacts are treated as not allowed
+  - Example of `quarkus-version` usage `-Dquarkus-version=3.8` or just run with example `-Dquarkus-version=example`
+  - These allowed artifacts config file needs to be stored in `src/main/resources` and should have format of `<quarkus_version>_allowed_artifacts.yaml`, where `_allowed_artifacts.yaml` is must have to work.

--- a/artifact-version-diff/pom.xml
+++ b/artifact-version-diff/pom.xml
@@ -43,16 +43,13 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${version.jackson-dataformat-yaml}</version>
         </dependency>
-
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/artifact-version-diff/pom.xml
+++ b/artifact-version-diff/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.quarkus.qe</groupId>
+    <artifactId>diff-utils</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <version.junit>5.10.2</version.junit>
+        <version.org.apache.maven.maven-artifact>3.9.6</version.org.apache.maven.maven-artifact>
+        <version.org.yaml.snakeyaml>2.2</version.org.yaml.snakeyaml>
+        <version.org.apache.maven.plugins>3.12.1</version.org.apache.maven.plugins>
+        <version.exec-maven-plugin>3.2.0</version.exec-maven-plugin>
+        <version.jackson-dataformat-yaml>2.17.0</version.jackson-dataformat-yaml>
+        <version.maven-surefire-plugin>3.2.5</version.maven-surefire-plugin>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${version.junit}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${version.org.apache.maven.maven-artifact}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${version.jackson-dataformat-yaml}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.org.apache.maven.plugins}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${version.exec-maven-plugin}</version>
+                <configuration>
+                    <mainClass>io.quarkus.qe.Main</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.maven-surefire-plugin}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/artifact-version-diff/prod_vs_upstream.sh
+++ b/artifact-version-diff/prod_vs_upstream.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Script need two arguments
+# 1st is RHBQ platform bom version
+# 2nd argument is path to local maven repository
+
+QUARKUS_PLATFORM_BOM_VERSION=$1
+QUARKUS_REPO_TAG=$(echo $QUARKUS_PLATFORM_BOM_VERSION | sed 's/[-.]redhat.*$//')
+MAVEN_REPO_LOCAL=$2
+
+mvn clean install exec:java -DskipTests -Dmaven.repo.local=${MAVEN_REPO_LOCAL} -Dquarkus.platform.bom=com.redhat.quarkus.platform:quarkus-bom:${QUARKUS_PLATFORM_BOM_VERSION} -Dquarkus.repo.tag=${QUARKUS_REPO_TAG}

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/AllowedArtifacts.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/AllowedArtifacts.java
@@ -1,0 +1,53 @@
+package io.quarkus.qe;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Datatype class for jackson serialization of yaml file
+ */
+public class AllowedArtifacts {
+
+    @JsonProperty("allowed-artifacts")
+    private List<AllowedArtifact> allowedArtifact;
+
+    public AllowedArtifacts() {
+    }
+
+    public List<AllowedArtifact> getAllowedArtifact() {
+        return allowedArtifact;
+    }
+
+    public void setAllowedArtifact(List<AllowedArtifact> allowedArtifact) {
+        this.allowedArtifact = allowedArtifact;
+    }
+
+    public static class AllowedArtifact {
+
+        @JsonProperty("artifact")
+        private String artifact;
+        @JsonProperty("allowed-rhbq-versions")
+        private List<String> rhbqVersions = new ArrayList<String>();
+
+        public AllowedArtifact() {
+        }
+
+        public String getArtifact() {
+            return artifact;
+        }
+
+        public void setArtifact(String artifact) {
+            this.artifact = artifact;
+        }
+
+        public List<String> getRhbqVersions() {
+            return rhbqVersions;
+        }
+
+        public void setRhbqVersions(List<String> rhbqVersions) {
+            this.rhbqVersions = rhbqVersions;
+        }
+    }
+}

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/Artifact.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/Artifact.java
@@ -1,0 +1,41 @@
+package io.quarkus.qe;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Artifact {
+    private HashMap<String, List<String>> duplicates;
+
+    public Artifact(String location, String versions) {
+        duplicates = new HashMap<>();
+        List<String> locations = new ArrayList<>(Arrays.asList(location));
+        duplicates.put(versions, locations);
+    }
+
+    public void addArtifactVersionAndLocation(String location, String versions) {
+        if (duplicates.containsKey(versions)) {
+            duplicates.get(versions).add(location);
+        } else {
+            List<String> locations = new ArrayList<>(Arrays.asList(location));
+            duplicates.put(versions, locations);
+        }
+    }
+
+    public List<String> getDifferentVersions() {
+        return duplicates.keySet().stream().toList();
+    }
+
+    /**
+     * Create string of affected location used in detailed report
+     * @param version version string used as key in map
+     * @return list of location
+     */
+    public String locationForVersion(String version) {
+        return duplicates.get(version).stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining("<br>"));
+    }
+}

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/Artifact.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/Artifact.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class Artifact {
@@ -37,5 +39,37 @@ public class Artifact {
         return duplicates.get(version).stream()
                 .map(String::valueOf)
                 .collect(Collectors.joining("<br>"));
+    }
+
+    /**
+     * Comparing version if they are the same.
+     * Also modify them as they are differences between upstream and productized artifact
+     * @param versionsTogether versions to be compared in format <upstream_version> -> <downstream_version>
+     * @return false if the version are not the same
+     */
+    public static boolean versionComparator(String versionsTogether) {
+        // separate upstream version from downstream
+        String[] versions = versionsTogether.replaceAll("\\s+", "").split("->");
+
+        // prod creating artifact in format major.minor.patch.redhat-NNNNN or major.minor.patch.suffix-redhat-NNNNN
+        String version = versions[0].replaceFirst("-", ".");
+
+        // match any artifact which have only major and minor version
+        Pattern pattern = Pattern.compile("^(\\d+\\.\\d+$)");
+        Matcher matcher = pattern.matcher(version);
+        // match any artifact which have only major and minor version and some suffix
+        Pattern pattern2 = Pattern.compile("^(\\d+\\.\\d+((\\.)\\D))");
+        Matcher matcher2 = pattern2.matcher(version);
+        // transform upstream version from major.minor to major.minor.0
+        if (matcher.find()) {
+            version += ".0";
+        }
+        // transform upstream version from major.minor-<suffix> to major.minor.0-suffix
+        // eg 1.77.alpha to 1.77.0.alpha
+        if (matcher2.find()) {
+            String versionHelper = matcher2.group();
+            version = version.substring(0, versionHelper.length() -2) + ".0" + version.substring(versionHelper.length() -2);
+        }
+        return versions[1].contains(version);
     }
 }

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/GenerateReport.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/GenerateReport.java
@@ -1,0 +1,341 @@
+package io.quarkus.qe;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class GenerateReport {
+
+    public static final String HTML_BASE_START = """
+            <!DOCTYPE html>
+            <html>
+            <style>
+                table, td, th {
+                    border: 1px solid;
+                    vertical-align: top;
+                    text-align: left;
+                    padding: 5px;
+                }
+
+                table {
+                    width: 100%;
+                    border-collapse: collapse;
+                }
+                .newer {
+                    background-color: #FFDD88;
+                }
+                .older {
+                    background-color: #EE9999;
+                }
+            </style>
+            <body>
+            <div>
+                <table>""";
+
+    public static final String HTML_BASE_END = """
+                </table>
+            </div>
+            </body>
+            </html>""";
+    public static final String ALLOWED_ARTIFACTS_BASE = "_allowed_artifacts.yaml";
+    public TreeMap<String, Artifact> differentArtifacts = new TreeMap<>();
+
+    Map<String, List<String>> allowedArtifacts;
+
+    private boolean majorMinorVersionDiffer = false;
+    private boolean patchOrOthersVersionDiffer = false;
+
+    public GenerateReport() {
+        createAllowedHashMap();
+    }
+
+    public void generateReport() {
+        String basePath = Objects.requireNonNull(System.getProperty("path-to-quarkus-repository"));
+        String versionDiffOutputFileName = Objects.requireNonNull(System.getProperty("version-plugin.report-output-file"));
+        List<Path> dependencyDiffFiles = generateListOfDiffFiles();
+
+        for (Path path : dependencyDiffFiles) {
+
+            try (Stream<String> lines = Files.lines(path)) {
+                lines.forEach(line -> {
+                    Pattern artifactPattern = Pattern.compile("[\\w.-]+:[\\w.-]+");
+                    Pattern versionsPattern = Pattern.compile("[\\S\\d.]+.->.+");
+                    Matcher artifactMatcher = artifactPattern.matcher(line);
+                    Matcher versionsMatcher = versionsPattern.matcher(line);
+                    if (artifactMatcher.matches() && !versionsMatcher.matches()) {
+                        throw new RuntimeException("Matcher not found");
+                    }
+                    if (artifactMatcher.find() && versionsMatcher.find()) {
+                        String versionsTogether = versionsMatcher.group();
+                        String[] versions = versionsTogether.replaceAll("\\s+", "").split("->");
+                        if (!versionComparator(versions[0], versions[1])) {
+                            String artifact = artifactMatcher.group();
+                            addToDifferentArtifacts(artifact,
+                                    path.toString().replace(basePath, "").replace(versionDiffOutputFileName, ""),
+                                    versionsTogether);
+                        }
+                    }
+                });
+            } catch (IOException e) {
+               throw new RuntimeException("Error when reading diff file lines for different dependencies. Error log: " + e);
+            }
+        }
+        generateSimpleOverview();
+        generateOverview();
+    }
+
+    /**
+     * Generate simple report containing only artifact name and different versions
+     * This output is saved in outputDiff.html file as table
+     */
+    public void generateSimpleOverview() {
+        String tableHeader = """
+                <tr>
+                    <td>Artifact</td>
+                    <td>Different version [upstream] -> [productized]</td>
+                </tr>""";
+
+        String template = """
+                <tr>
+                    <td>substitute-artifact</td>
+                    <td class="substitute-class">substitute-version</td>
+                </tr>
+                """;
+
+        try(FileWriter fw = new FileWriter("outputDiff.html")) {
+            fw.write(HTML_BASE_START);
+            fw.write(tableHeader);
+            for (String artifact : differentArtifacts.keySet()) {
+                List<String> versions = differentArtifacts.get(artifact).getDifferentVersions();
+                for (int i = 0; i < versions.size(); i++) {
+                    String writeCol = template;
+                    writeCol = i == 0 ? writeCol.replace("substitute-artifact", artifact) : writeCol.replace("substitute-artifact", "");
+                    writeCol = writeCol.replace("substitute-version", versions.get(i));
+                    writeCol = writeCol.replace("substitute-class", differencesInVersions(artifact, versions.get(i)));
+                    fw.write(writeCol);
+                }
+            }
+            fw.write(HTML_BASE_END);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to save output file. Log: " + e);
+        }
+    }
+
+    /**
+     * Generate simple report containing artifact name, different versions and location which are affected
+     * This output is saved in outputDiff.html file as table
+     */
+    public void generateOverview() {
+        String tableHeader = """
+                <tr>
+                    <td>Artifact</td>
+                    <td>Different version [upstream] -> [productized]</td>
+                    <td>Location of what is affected</td>
+                </tr>""";
+
+        String template = """
+                <tr>
+                    <td>substitute-artifact</td>
+                    <td>substitute-version</td>
+                    <td>substitute-locations</td>
+                </tr>
+                """;
+
+        try(FileWriter fw = new FileWriter("outputDiffDetailed.html")) {
+            fw.write(HTML_BASE_START);
+            fw.write(tableHeader);
+            for (String artifact : differentArtifacts.keySet()) {
+                List<String> versions = differentArtifacts.get(artifact).getDifferentVersions();
+                for (int i = 0; i < versions.size(); i++) {
+                    String writeColl = template;
+                    writeColl = i == 0 ? writeColl.replace("substitute-artifact", artifact) : writeColl.replace("substitute-artifact", "");
+                    writeColl = writeColl.replace("substitute-version", versions.get(i));
+                    writeColl = writeColl.replace("substitute-location", differentArtifacts.get(artifact).locationForVersion(versions.get(i)));
+                    fw.write(writeColl);
+                }
+            }
+            fw.write(HTML_BASE_END);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to save output file. Log: " + e);
+        }
+    }
+
+    /**
+     * Generate list of files generated by versions-maven-plugin inside of Quarkus repository
+     * @return List of paths to generated files
+     */
+    public List<Path> generateListOfDiffFiles() {
+        String basePath = Objects.requireNonNull(System.getProperty("path-to-quarkus-repository"));
+        String versionDiffOutputFileName = Objects.requireNonNull(System.getProperty("version-plugin.report-output-file"));
+        Path basePathToQuarkusRepository = Path.of(basePath);
+
+        try (Stream<Path> entries = Files.walk(basePathToQuarkusRepository)) {
+            return entries.filter(Files::isRegularFile)
+                    .filter(f -> f.getFileName().toString().contains(versionDiffOutputFileName) &&
+                            (f.toAbsolutePath().toString().contains(basePathToQuarkusRepository + File.separator + "bom") ||
+                                    f.toAbsolutePath().toString().contains(basePathToQuarkusRepository + File.separator + "core") ||
+                                    f.toAbsolutePath().toString().contains(basePathToQuarkusRepository + File.separator + "extensions") ||
+                                    f.toAbsolutePath().toString().contains(basePathToQuarkusRepository + File.separator + "test-framework")))
+                    .toList();
+        } catch (IOException e) {
+            throw new RuntimeException("Error when generating list of diff files. Error log: " + e);
+        }
+    }
+
+    /**
+     * Comparing version if they are the same.
+     * Also modify them as they are differences between upstream and productized artifact
+     * @param upstreamVersion Version of upstream artifact
+     * @param downstreamVersion version of downstream artifact
+     * @return false if the version are not the same
+     */
+    public boolean versionComparator(String upstreamVersion, String downstreamVersion) {
+        String version = upstreamVersion.replace("-alpha", ".alpha");
+
+        // match any artifact which have only major and minor version
+        Pattern pattern = Pattern.compile("^(\\d+\\.\\d+$)");
+        Matcher matcher = pattern.matcher(version);
+        // match any artifact which have only major and minor version and some suffix
+        Pattern pattern2 = Pattern.compile("^(\\d+\\.\\d+((\\.|-)\\D))");
+        Matcher matcher2 = pattern2.matcher(version);
+        if (matcher.find()) {
+            version += ".0";
+        }
+        if (matcher2.find()) {
+            String versionHelper = matcher2.group();
+            version = version.substring(0, versionHelper.length() -2) + ".0" + version.substring(versionHelper.length() -2);
+        }
+        return downstreamVersion.contains(version);
+    }
+
+    public void addToDifferentArtifacts(String artifact, String location, String versions) {
+        if(differentArtifacts.containsKey(artifact)) {
+            differentArtifacts.get(artifact).addArtifactVersionAndLocation(location, versions);
+        } else {
+            differentArtifacts.put(artifact, new Artifact(location, versions));
+        }
+    }
+
+    /**
+     * Checking the difference only between major and minor versions to highlight them in html table.
+     * This also setting the flags for JUnit test to be able to modify the jenkins result as when there are only differences
+     * in patch version or others
+     * @param versionsTogether String of different version
+     * @return html class name to highlight the table cells
+     */
+    public String differencesInVersions(String artifact, String versionsTogether) {
+        String[] versions = versionsTogether.replaceAll("\\s+", "").split("->");
+        DefaultArtifactVersion upstream = new DefaultArtifactVersion(versions[0]);
+        DefaultArtifactVersion upstreamMajorMinor = new DefaultArtifactVersion(upstream.getMajorVersion() + "." +
+                upstream.getMinorVersion());
+        DefaultArtifactVersion downstream = new DefaultArtifactVersion(versions[1]);
+        DefaultArtifactVersion downstreamMajorMinor = new DefaultArtifactVersion(downstream.getMajorVersion() + "." +
+                downstream.getMinorVersion());
+
+        int versionComparison = upstreamMajorMinor.compareTo(downstreamMajorMinor);
+        if (allowedArtifacts != null && versionComparison < 0) {
+            isAllowedWithDifferentVersion(true, artifact, versions[1]);
+            return "newer";
+        } else if (allowedArtifacts != null && versionComparison > 0) {
+            isAllowedWithDifferentVersion(true, artifact, versions[1]);
+            return "older";
+        } else if (allowedArtifacts != null) {
+            isAllowedWithDifferentVersion(false, artifact, versions[1]);
+            return "";
+        } else if (versionComparison < 0) {
+            setMajorMinorPatch(true);
+            return "newer";
+        } else if (versionComparison > 0) {
+            setMajorMinorPatch(true);
+            return "older";
+        } else {
+            setMajorMinorPatch(false);
+            return "";
+        }
+    }
+
+    /**
+     *
+     * @param majorMinor is this comparison of the major or minor version
+     * @param artifact artifact name
+     * @param downstreamVersion downstream artifact version e.g. `1.15.0.redhat-00001`
+     */
+    public void isAllowedWithDifferentVersion(boolean majorMinor, String artifact, String downstreamVersion) {
+        if (!allowedArtifacts.containsKey(artifact)) {
+            setMajorMinorPatch(majorMinor);
+            return;
+        }
+
+        boolean versionContainsAllowed = false;
+        for (String version : allowedArtifacts.get(artifact)) {
+            if (downstreamVersion.contains(version)) {
+                versionContainsAllowed = true;
+                break;
+            }
+        }
+        if (!versionContainsAllowed) {
+            setMajorMinorPatch(majorMinor);
+        }
+    }
+
+    public void setMajorMinorPatch(boolean majorMinor) {
+        if (majorMinor) {
+            majorMinorVersionDiffer = true;
+        } else {
+            patchOrOthersVersionDiffer = true;
+        }
+    }
+
+    /**
+     * Creating the hashmap with artifacts and version which are allowed to have different version from upstream
+     */
+    public void createAllowedHashMap() {
+        String quarkusVersion = Objects.requireNonNullElse(System.getProperty("quarkus-version"), "");
+        if (quarkusVersion.isBlank()) {
+            return;
+        }
+        allowedArtifacts = new HashMap<>();
+        String resourceName = "/" + quarkusVersion + ALLOWED_ARTIFACTS_BASE;
+        try {
+            InputStream inputStream = this.getClass().getResourceAsStream(resourceName);
+            ObjectMapper om = new ObjectMapper(new YAMLFactory());
+            AllowedArtifacts allowedArtifactList = om.readValue(inputStream, AllowedArtifacts.class);
+
+            for (AllowedArtifacts.AllowedArtifact allowedArtifact : allowedArtifactList.getAllowedArtifact()) {
+                if (!allowedArtifacts.containsKey(allowedArtifact.getArtifact())) {
+                    allowedArtifacts.put(allowedArtifact.getArtifact(), new ArrayList<>());
+                }
+                for (String version : allowedArtifact.getRhbqVersions()) {
+                    allowedArtifacts.get(allowedArtifact.getArtifact()).add(version);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error when loading allowed file " + resourceName + ". Log trace:", e);
+        }
+    }
+
+
+    public boolean isMajorMinorVersionDiffer() {
+        return majorMinorVersionDiffer;
+    }
+
+    public boolean isPatchOrOthersVersionDiffer() {
+        return patchOrOthersVersionDiffer;
+    }
+}

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/Main.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/Main.java
@@ -1,9 +1,13 @@
 package io.quarkus.qe;
 
+import java.io.IOException;
+import java.nio.file.Path;
+
 public class Main {
 
-    public static void main(String[] args) {
-        GenerateReport report = new GenerateReport();
+    public static void main(String[] args) throws IOException {
+        Path quarkusRepoDirectory = PrepareOperation.prepareVersionPluginOutput();
+        GenerateReport report = new GenerateReport(quarkusRepoDirectory);
         report.generateReport();
     }
 }

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/Main.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/Main.java
@@ -1,0 +1,9 @@
+package io.quarkus.qe;
+
+public class Main {
+
+    public static void main(String[] args) {
+        GenerateReport report = new GenerateReport();
+        report.generateReport();
+    }
+}

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/PrepareOperation.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/PrepareOperation.java
@@ -1,0 +1,82 @@
+package io.quarkus.qe;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PrepareOperation {
+
+    public static final String VERSION_PLUGIN_OUTPUT_FILE_NAME = "depDiffs.txt";
+    private static final Logger LOG = Logger.getLogger(PrepareOperation.class.getName());
+
+    /**
+     * Clone Quarkus repository with specific tag and execute `mvn versions:compare-dependencies`
+     * @return path to directory which include Quarkus
+     * @throws IOException
+     */
+    public static Path prepareVersionPluginOutput() throws IOException {
+        String generatedRandomDirName = "artifact-comparison-" + RandomStringUtils.randomAlphabetic(5);
+        Path tmpDirectory = Files.createDirectories(Paths.get(System.getProperty("java.io.tmpdir"), generatedRandomDirName));
+
+        LOG.info("Cloning Quarkus repository");
+        String branch = Objects.requireNonNull(System.getProperty("quarkus.repo.tag"), "The quarkus.repo.tag property wasn't set.");
+        List<String> gitCloneQuarkus = new ArrayList<>(
+                Arrays.asList("git", "clone", "--single-branch", "--branch", branch, "https://github.com/quarkusio/quarkus.git"));
+        executeProcess(gitCloneQuarkus, "Failed to clone Quarkus repository", tmpDirectory);
+
+        LOG.info("Executing mvn versions:compare-dependencies");
+        List<String> mvnVersionsExecute = new ArrayList<>(Arrays.asList("mvn", "versions:compare-dependencies"));
+        mvnVersionsExecute.addAll(prepareMavenProperties());
+        Path quarkusRepoDirectory = Paths.get(tmpDirectory.toAbsolutePath().toString(), "quarkus");
+        executeProcess(mvnVersionsExecute, "Failed to add remote origin", quarkusRepoDirectory);
+
+        return quarkusRepoDirectory;
+    }
+
+    public static void executeProcess(List<String> command, String errorMsg, Path path) {
+        ProcessBuilder builder = new ProcessBuilder(command);
+        builder.directory(path.toFile());
+        try {
+            Process process = builder.redirectErrorStream(true)
+                    .directory(path.toFile())
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
+                    .start();
+            process.waitFor();
+            assertEquals(0, process.exitValue(), errorMsg);
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**\
+     * Prepare properties for versions maven plugin.
+     * These properties are `maven.repo.local` (optional), `remotePom` and `reportOutputFile`
+     * @return list containing the properties
+     */
+    public static List<String> prepareMavenProperties() {
+        List<String> extraProperties = new ArrayList<>();
+        String localRepo = Objects.requireNonNullElse(System.getProperty("maven.repo.local"), "");
+        if (!localRepo.isEmpty()) {
+            extraProperties.add("-Dmaven.repo.local=" + localRepo);
+        }
+
+        String remotePom = Objects.requireNonNull(System.getProperty("quarkus.platform.bom"), "The quarkus.platform.bom wasn't set.");
+        extraProperties.add("-DremotePom=" + remotePom);
+
+        extraProperties.add("-DreportOutputFile=" + VERSION_PLUGIN_OUTPUT_FILE_NAME);
+
+        return extraProperties;
+    }
+
+}

--- a/artifact-version-diff/src/main/resources/example_allowed_artifacts.yaml
+++ b/artifact-version-diff/src/main/resources/example_allowed_artifacts.yaml
@@ -1,0 +1,11 @@
+allowed-artifacts:
+  - artifact:
+      'com.aayushatharva.brotli4j:brotli4j'
+    allowed-rhbq-versions:
+      - 1.14.0.redhat-00001
+      - 1.15.0.redhat-00001
+  - artifact:
+      'net.java.dev.jna:jna-platform'
+    allowed-rhbq-versions:
+      - 5.8.0
+

--- a/artifact-version-diff/src/test/java/io/quarkus/qe/DiffReportTest.java
+++ b/artifact-version-diff/src/test/java/io/quarkus/qe/DiffReportTest.java
@@ -3,12 +3,16 @@ package io.quarkus.qe;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.Path;
+
 
 public class DiffReportTest {
 
     @Test
-    public void checkNoArtifactHave() {
-        GenerateReport report = new GenerateReport();
+    public void checkNoArtifactHave() throws IOException {
+        Path quarkusRepoDirectory = PrepareOperation.prepareVersionPluginOutput();
+        GenerateReport report = new GenerateReport(quarkusRepoDirectory);
         report.generateReport();
         // Just check to throw exception for jenkins to mark builds differently
         Assertions.assertFalse(report.isMajorMinorVersionDiffer(),

--- a/artifact-version-diff/src/test/java/io/quarkus/qe/DiffReportTest.java
+++ b/artifact-version-diff/src/test/java/io/quarkus/qe/DiffReportTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.qe;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+public class DiffReportTest {
+
+    @Test
+    public void checkNoArtifactHave() {
+        GenerateReport report = new GenerateReport();
+        report.generateReport();
+        // Just check to throw exception for jenkins to mark builds differently
+        Assertions.assertFalse(report.isMajorMinorVersionDiffer(),
+                "Version differs in major or minor version marking as failure");
+        Assertions.assertFalse(report.isPatchOrOthersVersionDiffer(),
+                "Version differs in patch version or others marking as unstable");
+    }
+}


### PR DESCRIPTION
Adding the utility for camparing the upstream vs RHBQ. It can compare two different upstream version which can be also useful to see what was bumped.

The result can be seen on jenkins job with name compare-artifacts-versions-upstream-vs-prod (no link because of security)

It can be used separately using `exec` plugin or testing the result (which will be used in job to automate it)