### PR TITLE
3.2 allowlist and parsing bug fix

### DIFF
--- a/artifact-version-diff/src/main/java/io/quarkus/qe/Artifact.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/Artifact.java
@@ -52,7 +52,8 @@ public class Artifact {
         String[] versions = versionsTogether.replaceAll("\\s+", "").split("->");
 
         // prod creating artifact in format major.minor.patch.redhat-NNNNN or major.minor.patch.suffix-redhat-NNNNN
-        String version = versions[0].replaceFirst("-", ".");
+        // Change from `-` to `.` is happening only when the number is before `-`
+        String version = versions[0].replaceFirst("(?<=\\d)-", ".");
 
         // match any artifact which have only major and minor version
         Pattern pattern = Pattern.compile("^(\\d+\\.\\d+$)");

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/GenerateReport.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/GenerateReport.java
@@ -242,6 +242,14 @@ public class GenerateReport {
         DefaultArtifactVersion downstreamMajorMinor = new DefaultArtifactVersion(downstream.getMajorVersion() + "." +
                 downstream.getMinorVersion());
 
+        // If the productized version is to complicated (graal-sdk for example 23.1.2.0-3-redhat-00001) `DefaultArtifactVersion`
+        // not parse major and minor version correctly but get these values to 0.0
+        // This check manually get major and minor version from productized version
+        if (downstream.getMajorVersion() == 0 && downstream.getMinorVersion() == 0) {
+            String[] complicateVersion = versions[1].split("\\.");
+            downstreamMajorMinor = new DefaultArtifactVersion(complicateVersion[0] + "." + complicateVersion[1]);
+        }
+
         int versionComparison = upstreamMajorMinor.compareTo(downstreamMajorMinor);
         if (allowedArtifacts != null && versionComparison < 0) {
             isAllowedWithDifferentVersion(true, artifact, versions[1]);

--- a/artifact-version-diff/src/main/resources/3.2_allowed_artifacts.yaml
+++ b/artifact-version-diff/src/main/resources/3.2_allowed_artifacts.yaml
@@ -1,0 +1,106 @@
+allowed-artifacts:
+  - artifact:
+      'com.aayushatharva.brotli4j:brotli4j'
+    allowed-rhbq-versions:
+      - 1.12.0.redhat-00005
+  - artifact:
+      'com.google.guava:guava'
+    allowed-rhbq-versions:
+      - 32.0.1.jre-redhat-00001
+  - artifact:
+      'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations-support'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00001
+  - artifact:
+      'io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00001
+  - artifact:
+      'io.opentelemetry:opentelemetry-api-events'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00002
+  - artifact:
+      'io.opentelemetry:opentelemetry-api-logs'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00002
+  - artifact:
+      'io.opentelemetry:opentelemetry-exporter-otlp-logs'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00002
+  - artifact:
+      'io.opentelemetry:opentelemetry-exporter-prometheus'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00002
+  - artifact:
+      'io.opentelemetry:opentelemetry-extension-incubator'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00002
+  - artifact:
+      'io.opentelemetry:opentelemetry-opencensus-shim'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00002
+  - artifact:
+      'io.opentelemetry:opentelemetry-opentracing-shim'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00002
+  - artifact:
+      'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00002
+  - artifact:
+      'io.opentelemetry:opentelemetry-sdk-extension-incubator'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00002
+  - artifact:
+      'io.opentelemetry:opentelemetry-sdk-logs'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00002
+  - artifact:
+      'io.opentelemetry:opentelemetry-sdk-logs-testing'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00002
+  - artifact:
+      'io.opentelemetry:opentelemetry-semconv'
+    allowed-rhbq-versions:
+      - 1.25.0.redhat-00002
+  - artifact:
+      'net.java.dev.jna:jna-platform'
+    allowed-rhbq-versions:
+      - 5.8.0
+  - artifact:
+      'org.graalvm.nativeimage:svm'
+    allowed-rhbq-versions:
+      - 23.0.2.0-1-redhat-00001
+  - artifact:
+      'org.graalvm.sdk:graal-sdk'
+    allowed-rhbq-versions:
+      - 23.0.2.0-1-redhat-00001
+  - artifact:
+      'org.keycloak:keycloak-adapter-core'
+    allowed-rhbq-versions:
+      - 22.0.6.redhat-00002
+  - artifact:
+      'org.keycloak:keycloak-adapter-spi'
+    allowed-rhbq-versions:
+      - 22.0.6.redhat-00002
+  - artifact:
+      'org.keycloak:keycloak-admin-client'
+    allowed-rhbq-versions:
+      - 22.0.6.redhat-00002
+  - artifact:
+      'org.keycloak:keycloak-authz-client'
+    allowed-rhbq-versions:
+      - 22.0.6.redhat-00002
+  - artifact:
+      'org.keycloak:keycloak-common'
+    allowed-rhbq-versions:
+      - 22.0.6.redhat-00002
+  - artifact:
+      'org.keycloak:keycloak-core'
+    allowed-rhbq-versions:
+      - 22.0.6.redhat-00002
+  - artifact:
+      'org.keycloak:keycloak-policy-enforcer'
+    allowed-rhbq-versions:
+      - 22.0.6.redhat-00002
+


### PR DESCRIPTION
Adding 3.2 allowlist for RHBQ 3.2.12.Final

Fix version parsing bug which was found out with `org.wildfly.common:wildfly-common:1.5.4.Final-format-001-redhat-00002` and `org.graalvm` versions