### PR TITLE
Add artifact check for between RHBQ and upstream Quarkus

### DIFF
--- a/artifact-version-diff/.gitignore
+++ b/artifact-version-diff/.gitignore
@@ -1,0 +1,19 @@
+# Eclipse
+.project
+.classpath
+.settings/
+bin/
+
+# IntelliJ
+.idea
+*.ipr
+*.iml
+*.iws
+
+# Maven
+target/
+
+# Genarated files
+outputDiff.html
+outputDiffDetailed.html
+platformBomComparison.html

--- a/artifact-version-diff/pom.xml
+++ b/artifact-version-diff/pom.xml
@@ -18,6 +18,7 @@
         <version.exec-maven-plugin>3.2.0</version.exec-maven-plugin>
         <version.jackson-dataformat-yaml>2.17.0</version.jackson-dataformat-yaml>
         <version.maven-surefire-plugin>3.2.5</version.maven-surefire-plugin>
+        <version.maven-model>3.9.8</version.maven-model>
     </properties>
 
     <dependencyManagement>
@@ -42,6 +43,11 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${version.jackson-dataformat-yaml}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${version.maven-model}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/AllowedArtifacts.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/AllowedArtifacts.java
@@ -10,18 +10,39 @@ import java.util.List;
  */
 public class AllowedArtifacts {
 
-    @JsonProperty("allowed-artifacts")
-    private List<AllowedArtifact> allowedArtifact;
+    @JsonProperty("allowed-artifacts-version-comparison")
+    private List<AllowedArtifact> versionComparisonsArtifacts;
+    @JsonProperty("allowed-missing-artifacts-bom-comparison")
+    private List<String> bomComparisonsMissingArtifacts;
+    @JsonProperty("allowed-extra-artifacts-bom-comparison")
+    private List<String> bomComparisonsExtraArtifacts;
 
     public AllowedArtifacts() {
     }
 
-    public List<AllowedArtifact> getAllowedArtifact() {
-        return allowedArtifact;
+    public List<AllowedArtifact> getVersionComparisonsArtifacts() {
+        return versionComparisonsArtifacts;
     }
 
-    public void setAllowedArtifact(List<AllowedArtifact> allowedArtifact) {
-        this.allowedArtifact = allowedArtifact;
+    public void setVersionComparisonsArtifacts(
+            List<AllowedArtifact> versionComparisonsArtifacts) {
+        this.versionComparisonsArtifacts = versionComparisonsArtifacts;
+    }
+
+    public List<String> getBomComparisonsMissingArtifacts() {
+        return bomComparisonsMissingArtifacts;
+    }
+
+    public void setBomComparisonsMissingArtifacts(List<String> bomComparisonsMissingArtifacts) {
+        this.bomComparisonsMissingArtifacts = bomComparisonsMissingArtifacts;
+    }
+
+    public List<String> getBomComparisonsExtraArtifacts() {
+        return bomComparisonsExtraArtifacts;
+    }
+
+    public void setBomComparisonsExtraArtifacts(List<String> bomComparisonsExtraArtifacts) {
+        this.bomComparisonsExtraArtifacts = bomComparisonsExtraArtifacts;
     }
 
     public static class AllowedArtifact {
@@ -29,7 +50,7 @@ public class AllowedArtifacts {
         @JsonProperty("artifact")
         private String artifact;
         @JsonProperty("allowed-rhbq-versions")
-        private List<String> rhbqVersions = new ArrayList<String>();
+        private List<String> rhbqVersions = new ArrayList<>();
 
         public AllowedArtifact() {
         }

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/GeneratePomComparison.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/GeneratePomComparison.java
@@ -1,0 +1,126 @@
+package io.quarkus.qe;
+
+import org.apache.maven.model.Dependency;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.logging.Logger;
+
+public class GeneratePomComparison {
+
+    private final PomComparator pomComparator;
+    private final AllowedArtifacts allowedArtifactsFile;
+    private boolean allArtifactAreAllowed = true;
+
+    public static final String HTML_BASE_START = """
+            <!DOCTYPE html>
+            <html>
+            <style>
+                table, td, th {
+                    border: 1px solid;
+                    vertical-align: top;
+                    text-align: left;
+                    padding: 5px;
+                }
+
+                table {
+                    width: 100%;
+                    border-collapse: collapse;
+                }
+                .not-allowed {
+                    background-color: #EE9999;
+                }
+            </style>
+            <body>
+            <div>""";
+
+    public static final String HTML_BASE_END = """
+            </div>
+            </body>
+            </html>""";
+    public String template = """
+                <tr>
+                    <td class="not-allowed">substitute-artifact</td>
+                </tr>
+                """;
+    private static final Logger LOG = Logger.getLogger(GeneratePomComparison.class.getName());
+
+    public GeneratePomComparison(AllowedArtifacts allowedArtifactsFile) throws IOException, XmlPullParserException {
+        pomComparator = new PomComparator();
+        pomComparator.comparePoms();
+        this.allowedArtifactsFile = allowedArtifactsFile;
+    }
+
+
+    /**
+     * Generate report of platform bom comparison of artifacts
+     * The output is saved to platformBomComparison.html
+     * There is need to check if `allowedArtifactsFile` is not null otherwise the exception is thrown.
+     */
+    public void generatePomComparisonReport() {
+        LOG.info("Generating platform bom comparison report");
+        try(FileWriter fw = new FileWriter("platformBomComparison.html")) {
+            fw.write(HTML_BASE_START);
+
+            fw.write("<h1>RHBQ BOM - missing artifacts</h1>\n<table>");
+            fw.write(generateDifferArtifacts(pomComparator.getMissingDependencies(),
+                    allowedArtifactsFile != null ? allowedArtifactsFile.getBomComparisonsMissingArtifacts() : null));
+            fw.write("</table>");
+
+            fw.write("<h1>RHBQ BOM - extra artifacts</h1>\n<table>");
+            fw.write(generateDifferArtifacts(pomComparator.getExtraDependencies(),
+                    allowedArtifactsFile != null ? allowedArtifactsFile.getBomComparisonsExtraArtifacts() : null));
+            fw.write("</table>");
+
+            fw.write(HTML_BASE_END);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to save output file. Log: " + e);
+        }
+    }
+
+    /**
+     * Transform different artifacts list to simple html table. Check for each artifact if is in allow list
+     * @param differentArtifact List which will be transformed
+     * @param allowedArtifacts List of allowed artifacts as string which will be mark as allowed
+     * @return HTML table as string
+     */
+    public String generateDifferArtifacts(List<Dependency> differentArtifact, List<String> allowedArtifacts) {
+        StringBuilder missingArtifactsString = new StringBuilder();
+
+        differentArtifact.sort(new DependencyComparator());
+
+        for (Dependency dependency : differentArtifact) {
+            String artifact = dependency.getGroupId() + ":" + dependency.getArtifactId();
+            String stringTemplate = template.replace("substitute-artifact", artifact);
+            if (allowedArtifacts != null && allowedArtifacts.contains(artifact)) {
+                stringTemplate = stringTemplate.replace("not-allowed", "");
+            } else {
+                allArtifactAreAllowed = false;
+            }
+            missingArtifactsString.append(stringTemplate);
+        }
+        return missingArtifactsString.toString();
+    }
+
+    public boolean isAllArtifactAreAllowed() {
+        return allArtifactAreAllowed;
+    }
+
+    /**
+     * Comparator class used to sort list containing Dependencies
+     */
+    static class DependencyComparator implements Comparator<Dependency> {
+        @Override
+        public int compare(Dependency dep1, Dependency dep2) {
+            int groupIdComparison = dep1.getGroupId().compareTo(dep2.getGroupId());
+            if (groupIdComparison != 0) {
+                return groupIdComparison;
+            } else {
+                return dep1.getArtifactId().compareTo(dep2.getArtifactId());
+            }
+        }
+    }
+}

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/GeneratePomComparison.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/GeneratePomComparison.java
@@ -5,6 +5,7 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import java.io.FileWriter;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Logger;
@@ -35,11 +36,15 @@ public class GeneratePomComparison {
                 }
             </style>
             <body>
+            <div><h1>Compared Quarkus versions substitute-quarkus-upstream vs substitute-quarkus-rhbq</h1></div>
             <div>""";
 
     public static final String HTML_BASE_END = """
             </div>
             </body>
+            <footer>
+                <p>Generated on substitute-date</p>
+            </footer>
             </html>""";
     public String template = """
                 <tr>
@@ -63,19 +68,20 @@ public class GeneratePomComparison {
     public void generatePomComparisonReport() {
         LOG.info("Generating platform bom comparison report");
         try(FileWriter fw = new FileWriter("platformBomComparison.html")) {
-            fw.write(HTML_BASE_START);
+            fw.write(HTML_BASE_START.replace("substitute-quarkus-upstream", PrepareOperation.upstreamVersion)
+                    .replace("substitute-quarkus-rhbq", PrepareOperation.rhbqVersion));
 
-            fw.write("<h1>RHBQ BOM - missing artifacts</h1>\n<table>");
+            fw.write("<h2>RHBQ BOM - missing artifacts</h2>\n<table>");
             fw.write(generateDifferArtifacts(pomComparator.getMissingDependencies(),
                     allowedArtifactsFile != null ? allowedArtifactsFile.getBomComparisonsMissingArtifacts() : null));
             fw.write("</table>");
 
-            fw.write("<h1>RHBQ BOM - extra artifacts</h1>\n<table>");
+            fw.write("<h2>RHBQ BOM - extra artifacts</h2>\n<table>");
             fw.write(generateDifferArtifacts(pomComparator.getExtraDependencies(),
                     allowedArtifactsFile != null ? allowedArtifactsFile.getBomComparisonsExtraArtifacts() : null));
             fw.write("</table>");
 
-            fw.write(HTML_BASE_END);
+            fw.write(HTML_BASE_END.replace("substitute-date", new SimpleDateFormat("dd/MM/yyyy HH:mm:ss.SSS").format(new java.util.Date())));
         } catch (IOException e) {
             throw new RuntimeException("Unable to save output file. Log: " + e);
         }

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/GenerateVersionDiffReport.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/GenerateVersionDiffReport.java
@@ -7,6 +7,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -44,6 +45,7 @@ public class GenerateVersionDiffReport {
                 }
             </style>
             <body>
+            <div><h1>Compared Quarkus versions substitute-quarkus-upstream vs substitute-quarkus-rhbq</h1></div>
             <div>
                 <table>""";
 
@@ -51,6 +53,9 @@ public class GenerateVersionDiffReport {
                 </table>
             </div>
             </body>
+            <footer>
+                <p>Generated on substitute-date</p>
+            </footer>
             </html>""";
     public TreeMap<String, Artifact> differentArtifacts = new TreeMap<>();
 
@@ -129,7 +134,8 @@ public class GenerateVersionDiffReport {
 
         LOG.info("Generating simple diff report");
         try(FileWriter fw = new FileWriter("outputDiff.html")) {
-            fw.write(HTML_BASE_START);
+            fw.write(HTML_BASE_START.replace("substitute-quarkus-upstream", PrepareOperation.upstreamVersion)
+                    .replace("substitute-quarkus-rhbq", PrepareOperation.rhbqVersion));
             fw.write(tableHeader);
             for (String artifact : differentArtifacts.keySet()) {
                 List<String> versions = differentArtifacts.get(artifact).getDifferentVersions();
@@ -141,7 +147,7 @@ public class GenerateVersionDiffReport {
                     fw.write(writeCol);
                 }
             }
-            fw.write(HTML_BASE_END);
+            fw.write(HTML_BASE_END.replace("substitute-date", new SimpleDateFormat("dd/MM/yyyy HH:mm:ss.SSS").format(new java.util.Date())));
         } catch (IOException e) {
             throw new RuntimeException("Unable to save output file. Log: " + e);
         }
@@ -169,7 +175,8 @@ public class GenerateVersionDiffReport {
 
         LOG.info("Generating detailed diff report");
         try(FileWriter fw = new FileWriter("outputDiffDetailed.html")) {
-            fw.write(HTML_BASE_START);
+            fw.write(HTML_BASE_START.replace("substitute-quarkus-upstream", PrepareOperation.upstreamVersion)
+                    .replace("substitute-quarkus-rhbq", PrepareOperation.rhbqVersion));
             fw.write(tableHeader);
             for (String artifact : differentArtifacts.keySet()) {
                 List<String> versions = differentArtifacts.get(artifact).getDifferentVersions();
@@ -181,7 +188,7 @@ public class GenerateVersionDiffReport {
                     fw.write(writeColl);
                 }
             }
-            fw.write(HTML_BASE_END);
+            fw.write(HTML_BASE_END.replace("substitute-date", new SimpleDateFormat("dd/MM/yyyy HH:mm:ss.SSS").format(new java.util.Date())));
         } catch (IOException e) {
             throw new RuntimeException("Unable to save output file. Log: " + e);
         }

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/Main.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/Main.java
@@ -1,13 +1,18 @@
 package io.quarkus.qe;
 
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
 import java.io.IOException;
 import java.nio.file.Path;
 
 public class Main {
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, XmlPullParserException {
         Path quarkusRepoDirectory = PrepareOperation.prepareVersionPluginOutput();
-        GenerateReport report = new GenerateReport(quarkusRepoDirectory);
+        AllowedArtifacts allowedArtifactsFile = PrepareOperation.loadAllowedArtifactFile();
+        GenerateVersionDiffReport report = new GenerateVersionDiffReport(quarkusRepoDirectory, allowedArtifactsFile);
+        GeneratePomComparison pomComparison = new GeneratePomComparison(allowedArtifactsFile);
         report.generateReport();
+        pomComparison.generatePomComparisonReport();
     }
 }

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/PomComparator.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/PomComparator.java
@@ -1,0 +1,92 @@
+package io.quarkus.qe;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public class PomComparator {
+
+    private Path upstreamPlatformBom;
+    private Path rhbqPlatformBom;
+    private Map<String, Dependency> rhbqPlatformBomDependencies;
+    private List<Dependency> missingDependencies = new ArrayList<>();
+
+    private static final Logger LOG = Logger.getLogger(PomComparator.class.getName());
+
+    public PomComparator() throws IOException {
+        preparePlatformBoms();
+    }
+
+    public void preparePlatformBoms() throws IOException {
+        upstreamPlatformBom = PrepareOperation.getUpstreamBom();
+        rhbqPlatformBom = PrepareOperation.getRHBQBom();
+        if (!upstreamPlatformBom.toFile().exists() || !rhbqPlatformBom.toFile().exists()) {
+            throw new FileNotFoundException("The upstream or RHBQ platform bom doesn't exist");
+        }
+    }
+
+    /**
+     * Load upstream and RHBQ platform boms and compare them. It creates List for RHBQ missing upstream defined artifacts,
+     * List for RHBQ additional/extra artifacts and List for artifacts with different versions.
+     * The different version should be same as version comparison in GenerateVersionDiffReport.
+     * However, this check is not that thorough as in GenerateVersionDiffReport
+     * @throws IOException
+     * @throws XmlPullParserException
+     */
+    public void comparePoms() throws IOException, XmlPullParserException {
+        LOG.info("Upstream platform bom location: " + upstreamPlatformBom.toAbsolutePath());
+        LOG.info("RHBQ platform bom location: " + rhbqPlatformBom.toAbsolutePath());
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        Model upstreamPlatformBomModel = reader.read(new FileReader(upstreamPlatformBom.toFile()));
+        Model rhbqPlatformBomModel = reader.read(new FileReader(rhbqPlatformBom.toFile()));
+
+        // Load upstream bom and remove duplicate artifacts as we don't want to check for classifier. Example:
+        // `netty-transport-native-unix-common` have multiple classifier like osx-x86_64, linux-x86_64
+        List<Dependency> upstreamDependencies = upstreamPlatformBomModel.getDependencyManagement().getDependencies().stream()
+                .collect(Collectors.toMap(
+                        dep -> dep.getGroupId() + ":" + dep.getArtifactId(), dep -> dep, (dep1, dep2) -> dep2))
+                .values().stream().toList();
+
+        // Load RHBQ bom and change it to map for easier comparing
+        List<Dependency> rhbqDependencies = rhbqPlatformBomModel.getDependencyManagement().getDependencies();
+        rhbqPlatformBomDependencies = rhbqDependencies.stream().collect(Collectors.toMap(dep -> dep.getGroupId() + ":" + dep.getArtifactId(), Function.identity(), (artifact1, artifact2) -> artifact1));
+
+        for (Dependency dependency : upstreamDependencies) {
+            String key = dependency.getGroupId() + ":" + dependency.getArtifactId();
+            // As RHBQ rename platform groupId from io.quarkus to com.redhat.quarkus this need to changed
+            // as groupId:artifactId is used as key. In case of RHBQ it can't find these relocated artifacts
+            if (key.contains("quarkus-bom-quarkus-platform")) {
+                key = key.replace("io.quarkus", "com.redhat.quarkus");
+            }
+            if (!rhbqPlatformBomDependencies.containsKey(key)) {
+                missingDependencies.add(dependency);
+            } else {
+                rhbqPlatformBomDependencies.remove(key);
+            }
+        }
+    }
+
+    /**
+     *
+     * @return mutable List of dependencies created from Map
+     */
+    public List<Dependency> getExtraDependencies() {
+        return new ArrayList<>(rhbqPlatformBomDependencies.values());
+    }
+
+    public List<Dependency> getMissingDependencies() {
+        return missingDependencies;
+    }
+}

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/PrepareOperation.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/PrepareOperation.java
@@ -128,7 +128,7 @@ public class PrepareOperation {
      * Creating the hashmap with artifacts and version which are allowed to have different version from upstream
      */
     public static Map<String, List<String>> createAllowedHashMap(AllowedArtifacts loadedAllowedArtifacts) {
-        if (loadedAllowedArtifacts == null) {
+        if (loadedAllowedArtifacts == null || loadedAllowedArtifacts.getVersionComparisonsArtifacts() == null) {
             return null;
         }
         Map<String, List<String>> allowedArtifacts = new HashMap<>();

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/PrepareOperation.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/PrepareOperation.java
@@ -25,6 +25,9 @@ public class PrepareOperation {
     public static final String ALLOWED_ARTIFACTS_BASE = "_allowed_artifacts.yaml";
     private static final Logger LOG = Logger.getLogger(PrepareOperation.class.getName());
 
+    public static String rhbqVersion;
+    public static String upstreamVersion;
+
     /**
      * Clone Quarkus repository with specific tag and execute `mvn versions:compare-dependencies`
      * @return path to directory which include Quarkus
@@ -103,15 +106,15 @@ public class PrepareOperation {
      */
     public static Path getUpstreamBom() {
         LOG.info("Executing mvn dependency:get");
-        String version = Objects.requireNonNull(System.getProperty("quarkus.repo.tag"), "The quarkus.platform.bom wasn't set.");
+        upstreamVersion = Objects.requireNonNull(System.getProperty("quarkus.repo.tag"), "The quarkus.platform.bom wasn't set.");
 
         List<String> mvnVersionsExecute = new ArrayList<>(
-                Arrays.asList("mvn", "dependency:get", "-Dartifact=io.quarkus.platform:quarkus-bom:" + version + ":pom",
+                Arrays.asList("mvn", "dependency:get", "-Dartifact=io.quarkus.platform:quarkus-bom:" + upstreamVersion + ":pom",
                         "-Dmaven.repo.local=" + getLocalRepository()));
         executeProcess(mvnVersionsExecute, "Failed to execute dependency:get for downloading upstream platform bom.",
                 Paths.get("").toAbsolutePath());
 
-        return Paths.get(getLocalRepository(), "io", "quarkus", "platform", "quarkus-bom", version, "quarkus-bom-" + version + ".pom");
+        return Paths.get(getLocalRepository(), "io", "quarkus", "platform", "quarkus-bom", upstreamVersion, "quarkus-bom-" + upstreamVersion + ".pom");
     }
 
     /**
@@ -120,8 +123,8 @@ public class PrepareOperation {
      */
     public static Path getRHBQBom() {
         String platformBom = Objects.requireNonNull(System.getProperty("quarkus.platform.bom"), "The quarkus.platform.bom wasn't set.");
-        String version = platformBom.substring(platformBom.lastIndexOf(":") + 1);
-        return Paths.get(getLocalRepository(), "com", "redhat", "quarkus", "platform", "quarkus-bom", version, "quarkus-bom-" + version + ".pom");
+        rhbqVersion = platformBom.substring(platformBom.lastIndexOf(":") + 1);
+        return Paths.get(getLocalRepository(), "com", "redhat", "quarkus", "platform", "quarkus-bom", rhbqVersion, "quarkus-bom-" + rhbqVersion + ".pom");
     }
 
     /**
@@ -161,5 +164,4 @@ public class PrepareOperation {
             throw new RuntimeException("Error when loading allowed file " + resourceName + ". Log trace:", e);
         }
     }
-
 }

--- a/artifact-version-diff/src/main/resources/3.2_allowed_artifacts.yaml
+++ b/artifact-version-diff/src/main/resources/3.2_allowed_artifacts.yaml
@@ -1,4 +1,4 @@
-allowed-artifacts:
+allowed-artifacts-version-comparison:
   - artifact:
       'com.aayushatharva.brotli4j:brotli4j'
     allowed-rhbq-versions:

--- a/artifact-version-diff/src/main/resources/3.8_allowed_artifacts.yaml
+++ b/artifact-version-diff/src/main/resources/3.8_allowed_artifacts.yaml
@@ -1,5 +1,5 @@
-allowed-artifacts:
-  - artifact:  ## https://issues.redhat.com/browse/QUARKUS-4119
+allowed-artifacts-version-comparison:
+  - artifact: ## https://issues.redhat.com/browse/QUARKUS-4119
       'net.java.dev.jna:jna-platform'
     allowed-rhbq-versions:
       - 5.8.0

--- a/artifact-version-diff/src/main/resources/3.8_allowed_artifacts.yaml
+++ b/artifact-version-diff/src/main/resources/3.8_allowed_artifacts.yaml
@@ -1,5 +1,1 @@
 allowed-artifacts-version-comparison:
-  - artifact: ## https://issues.redhat.com/browse/QUARKUS-4119
-      'net.java.dev.jna:jna-platform'
-    allowed-rhbq-versions:
-      - 5.8.0

--- a/artifact-version-diff/src/main/resources/example_allowed_artifacts.yaml
+++ b/artifact-version-diff/src/main/resources/example_allowed_artifacts.yaml
@@ -8,4 +8,9 @@ allowed-artifacts:
       'net.java.dev.jna:jna-platform'
     allowed-rhbq-versions:
       - 5.8.0
+allowed-missing-artifacts-bom-comparison:
+  - io.quarkus:quarkus-rest-client-mutiny
+allowed-extra-artifacts-bom-comparison:
+  - com.aayushatharva.brotli4j:native-linux-ppc64le
+  - io.netty:netty-transport-native-epoll-ppcle
 

--- a/artifact-version-diff/src/test/java/io/quarkus/qe/DiffReportTest.java
+++ b/artifact-version-diff/src/test/java/io/quarkus/qe/DiffReportTest.java
@@ -1,6 +1,8 @@
 package io.quarkus.qe;
 
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -9,15 +11,32 @@ import java.nio.file.Path;
 
 public class DiffReportTest {
 
+    public static AllowedArtifacts allowedArtifactsFile;
+
+    @BeforeAll
+    public static void loadAllowedArtifact() {
+        allowedArtifactsFile = PrepareOperation.loadAllowedArtifactFile();
+    }
+
     @Test
     public void checkNoArtifactHave() throws IOException {
         Path quarkusRepoDirectory = PrepareOperation.prepareVersionPluginOutput();
-        GenerateReport report = new GenerateReport(quarkusRepoDirectory);
+
+        GenerateVersionDiffReport report = new GenerateVersionDiffReport(quarkusRepoDirectory, allowedArtifactsFile);
         report.generateReport();
         // Just check to throw exception for jenkins to mark builds differently
         Assertions.assertFalse(report.isMajorMinorVersionDiffer(),
                 "Version differs in major or minor version marking as failure");
         Assertions.assertFalse(report.isPatchOrOthersVersionDiffer(),
                 "Version differs in patch version or others marking as unstable");
+    }
+
+    @Test
+    public void checkForDifferentArtifactsInPlatformBoms() throws IOException, XmlPullParserException {
+        GeneratePomComparison pomComparison = new GeneratePomComparison(allowedArtifactsFile);
+        pomComparison.generatePomComparisonReport();
+        Assertions.assertTrue(pomComparison.isAllArtifactAreAllowed(),
+                "There are new missing/additional artifacts differ in platform bom. Check the output for more info. " +
+                        "Marking as failure");
     }
 }


### PR DESCRIPTION
This PR adding the check for missing/extra artifacts between RHBQ and upstream platform boms. In addition it checks the version of these artifacts (not thoroughly as previously developed check) so we checking it 2 times.

To check how this addition work you can use one of these commands using the RHBQ 3.8.5 maven-repo zip

`mvn clean install exec:java -DskipTests -Dquarkus.platform.bom=com.redhat.quarkus.platform:quarkus-bom:3.8.5.redhat-00003 -Dmaven.repo.local=<path to unziped RHBQ> -Dquarkus.repo.tag=3.8.5 -Dquarkus-version=3.8`

`mvn clean test -Dtest="DiffReportTest#checkForDifferentArtifactsInPlatformBoms" -Dquarkus.platform.bom=com.redhat.quarkus.platform:quarkus-bom:3.8.5.redhat-00003 -Dmaven.repo.local=<path to unziped RHBQ> -Dquarkus.repo.tag=3.8.5 -Dquarkus-version=3.8`

or for full all the checks

`mvn clean test -Dquarkus.platform.bom=com.redhat.quarkus.platform:quarkus-bom:3.8.5.redhat-00003 -Dmaven.repo.local=<path to unziped RHBQ> -Dquarkus.repo.tag=3.8.5 -Dquarkus-version=3.8`

Note that `mvn clean test` will fail as the `allowed_artifact.yaml` wasn't updated with latest exception!