### PR TITLE
Add logic to exclude know artifact which differ in version suffixes

### DIFF
--- a/artifact-version-diff/src/main/java/io/quarkus/qe/Artifact.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/Artifact.java
@@ -11,6 +11,9 @@ import java.util.stream.Collectors;
 public class Artifact {
     private HashMap<String, List<String>> duplicates;
 
+    // List of know artifact which differ between upstream and RHBQ
+    public static List<String> alwaysDifferentArtifact = Arrays.asList("opentelemetry-instrumentation-annotations-support", "opentelemetry-instrumentation-api-semconv");
+
     public Artifact(String location, String versions) {
         duplicates = new HashMap<>();
         List<String> locations = new ArrayList<>(Arrays.asList(location));
@@ -47,13 +50,18 @@ public class Artifact {
      * @param versionsTogether versions to be compared in format <upstream_version> -> <downstream_version>
      * @return false if the version are not the same
      */
-    public static boolean versionComparator(String versionsTogether) {
+    public static boolean versionComparator(String artifact, String versionsTogether) {
         // separate upstream version from downstream
         String[] versions = versionsTogether.replaceAll("\\s+", "").split("->");
 
         // prod creating artifact in format major.minor.patch.redhat-NNNNN or major.minor.patch.suffix-redhat-NNNNN
         // Change from `-` to `.` is happening only when the number is before `-`
         String version = versions[0].replaceFirst("(?<=\\d)-", ".");
+
+        // check if version is know to differ and strip it of know suffixes
+        if (isAlwaysDifferent(artifact)) {
+            version =stripAlphaSuffix(version);
+        }
 
         // match any artifact which have only major and minor version
         Pattern pattern = Pattern.compile("^(\\d+\\.\\d+$)");
@@ -72,5 +80,25 @@ public class Artifact {
             version = version.substring(0, versionHelper.length() -2) + ".0" + version.substring(versionHelper.length() -2);
         }
         return versions[1].contains(version);
+    }
+
+    /**
+     * Check if artifact is known to differ between upstream and RHBQ
+     *
+     * @param artifact artifact to be checked
+     * @return
+     */
+    public static boolean isAlwaysDifferent(String artifact) {
+        return alwaysDifferentArtifact.stream().anyMatch(artifact::contains);
+    }
+
+    /**
+     * Strip version of alpha suffix in know differences between upstream and downstream
+     *
+     * @param version version to be striped
+     * @return striped version of alpha suffix
+     */
+    public static String stripAlphaSuffix(String version) {
+        return version.replace(".alpha", "");
     }
 }

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/GenerateVersionDiffReport.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/GenerateVersionDiffReport.java
@@ -98,8 +98,8 @@ public class GenerateVersionDiffReport {
                     }
                     if (artifactMatcher.find() && versionsMatcher.find()) {
                         String versionsTogether = versionsMatcher.group();
-                        if (!Artifact.versionComparator(versionsTogether)) {
-                            String artifact = artifactMatcher.group();
+                        String artifact = artifactMatcher.group();
+                        if (!Artifact.versionComparator(artifact, versionsTogether)) {
                             addToDifferentArtifacts(artifact,
                                     path.toString().replace(quarkusRepoDirectory.toString(), "").replace(VERSION_PLUGIN_OUTPUT_FILE_NAME, ""),
                                     versionsTogether);


### PR DESCRIPTION
Adding the function to exclude the version modification between Quarkus and RHBQ. Atm it's only used for otel artifacts where Quarkus use alpha version.