### PR TITLE
Handling temporary versions with speciffic suffixes

### DIFF
--- a/artifact-version-diff/src/main/java/io/quarkus/qe/GeneratePomComparison.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/GeneratePomComparison.java
@@ -72,6 +72,9 @@ public class GeneratePomComparison {
                     .replace("substitute-quarkus-rhbq", PrepareOperation.rhbqVersion));
 
             fw.write("<h2>RHBQ BOM - missing artifacts</h2>\n<table>");
+            String missingArtifactsReport = generateDifferArtifacts(pomComparator.getMissingDependencies(),
+                    allowedArtifactsFile != null ? allowedArtifactsFile.getBomComparisonsMissingArtifacts() : null);
+            LOG.info("Missing artifacts: \n" + missingArtifactsReport);
             fw.write(generateDifferArtifacts(pomComparator.getMissingDependencies(),
                     allowedArtifactsFile != null ? allowedArtifactsFile.getBomComparisonsMissingArtifacts() : null));
             fw.write("</table>");

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/GenerateVersionDiffReport.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/GenerateVersionDiffReport.java
@@ -137,6 +137,7 @@ public class GenerateVersionDiffReport {
             fw.write(HTML_BASE_START.replace("substitute-quarkus-upstream", PrepareOperation.upstreamVersion)
                     .replace("substitute-quarkus-rhbq", PrepareOperation.rhbqVersion));
             fw.write(tableHeader);
+            StringBuilder diffReport = new StringBuilder();
             for (String artifact : differentArtifacts.keySet()) {
                 List<String> versions = differentArtifacts.get(artifact).getDifferentVersions();
                 for (int i = 0; i < versions.size(); i++) {
@@ -145,9 +146,12 @@ public class GenerateVersionDiffReport {
                     writeCol = writeCol.replace("substitute-version", versions.get(i));
                     writeCol = writeCol.replace("substitute-class", differencesInVersions(artifact, versions.get(i)));
                     fw.write(writeCol);
+                    diffReport.append("Artifact: ").append(artifact)
+                            .append(", Versions: ").append(versions.get(i)).append("\n");
                 }
             }
             fw.write(HTML_BASE_END.replace("substitute-date", new SimpleDateFormat("dd/MM/yyyy HH:mm:ss.SSS").format(new java.util.Date())));
+            LOG.info("Different versions report : \n" + diffReport);
         } catch (IOException e) {
             throw new RuntimeException("Unable to save output file. Log: " + e);
         }


### PR DESCRIPTION
We observed some issues in our job with improper handling of temporary suffixes such as redhat-* and temporary-*, which caused errors in BOM comparison and repository cloning.
 The fix normalizes the version by replacing the suffixes for upstream operations and improves logging to display detailed differences in missing, extra, and mismatched artifacts and versions