### PR TITLE
Disabled tests inspector

### DIFF
--- a/disabled-tests-inspector/.gitignore
+++ b/disabled-tests-inspector/.gitignore
@@ -1,0 +1,16 @@
+.classpath
+.settings
+.project
+target
+.factorypath
+bin
+*.iml
+../.idea
+
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+release.properties
+impsort-maven-cache.properties

--- a/disabled-tests-inspector/README.md
+++ b/disabled-tests-inspector/README.md
@@ -1,0 +1,31 @@
+# Disabled Tests Inspector
+
+## Overview
+**Disabled Tests Inspector** is a tool that analyzes Java test code in a GitHub repository, identifying disabled tests and categorizing them by annotation type and module. It generates a JSON report summarizing the findings.
+
+## Features
+- Scans Java test files for disabled test annotations
+- Extracts reasons and issue links from annotations and comments
+- Categorizes disabled tests per module
+- Generates structured JSON reports
+
+## Requirements
+- Java 17+
+- Maven 3.8.6+
+- A GitHub personal access token
+
+## Usage example
+If you want to inspect multiple branches, list them comma-separated in `branches` property as described in the example below:
+```shell
+export GITHUB_OAUTH=your_personal_access_token  
+mvn clean install
+java -DrepoOwner=repoOwner -DrepoName=repoName -Dbranches="main,3.15" -DbaseOutputFileName=disabled-tests -jar target/quarkus-app/quarkus-run.jar
+```
+
+## Example output
+After running the tool, you will get the following output files:
+
+1. `disabled-tests-3.15.json` – A detailed list of all disabled tests in `3.15` branch
+2. `disabled-tests-3.15-stats.json` – A summary of disabled tests per annotation type per module in `3.15` branch
+3. `disabled-tests-main.json` – A detailed list of all disabled tests in `main` branch
+4. `disabled-tests-main-stats.json` – A summary of disabled tests per annotation type per module in `main` branch

--- a/disabled-tests-inspector/pom.xml
+++ b/disabled-tests-inspector/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.quarkus.ts</groupId>
+    <artifactId>disabled-tests</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.17.8</quarkus.platform.version>
+        <skipITs>true</skipITs>
+        <surefire-plugin.version>3.5.2</surefire-plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>github-api</artifactId>
+            <version>1.135</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/disabled-tests-inspector/src/main/java/io/quarkus/ts/BranchAnalysisResult.java
+++ b/disabled-tests-inspector/src/main/java/io/quarkus/ts/BranchAnalysisResult.java
@@ -1,0 +1,19 @@
+package io.quarkus.ts;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class BranchAnalysisResult {
+
+    @JsonProperty("branch_name")
+    private String branch;
+
+    @JsonProperty("disabled_tests")
+    private List<DisabledTest> disabledTests;
+
+    public BranchAnalysisResult(String branch, List<DisabledTest> disabledTests) {
+        this.branch = branch;
+        this.disabledTests = disabledTests;
+    }
+}

--- a/disabled-tests-inspector/src/main/java/io/quarkus/ts/DisabledTest.java
+++ b/disabled-tests-inspector/src/main/java/io/quarkus/ts/DisabledTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.ts;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DisabledTest {
+
+    @JsonProperty("test_name")
+    private String testName;
+
+    @JsonProperty("class_name")
+    private String className;
+
+    @JsonProperty("annotation_type")
+    private String annotationType;
+
+    @JsonProperty("reason")
+    private String reason;
+
+    @JsonProperty("issue_link")
+    private String issueLink;
+
+    @JsonProperty("file_url")
+    private String fileURL;
+
+    @JsonProperty("issue_closed")
+    private boolean issueClosed;
+
+    public DisabledTest(String testName, String className, String annotationType, String reason, String issueLink, String fileURL, boolean issueClosed) {
+        this.testName = testName;
+        this.className = className;
+        this.annotationType = annotationType;
+        this.reason = reason;
+        this.issueLink = issueLink;
+        this.fileURL = fileURL;
+        this.issueClosed = issueClosed;
+    }
+}

--- a/disabled-tests-inspector/src/main/java/io/quarkus/ts/DisabledTestAnalyserService.java
+++ b/disabled-tests-inspector/src/main/java/io/quarkus/ts/DisabledTestAnalyserService.java
@@ -1,0 +1,217 @@
+package io.quarkus.ts;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHTree;
+import org.kohsuke.github.GHTreeEntry;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHIssueState;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+public class DisabledTestAnalyserService {
+
+    private static final Pattern CLASS_DECLARATION_PATTERN = Pattern.compile(
+            "public\\s+(?:\\w+\\s+)*class\\s+(\\w+)"
+    );
+
+    private static final Pattern TEST_METHOD_PATTERN = Pattern.compile(
+            "public\\s+void\\s+(\\w+)\\s*\\("
+    );
+
+    private static final Pattern DISABLED_ANNOTATION_PATTERN = Pattern.compile(
+            "@(Disabled\\w*)\\s*(?:\\((.*)\\))?"
+    );
+
+    private static final Pattern REASON_PATTERN = Pattern.compile(
+            "reason\\s*=\\s*\"([^\"]+)\"", Pattern.CASE_INSENSITIVE
+    );
+
+    private static final Pattern EXPLICIT_REASON_PATTERN = Pattern.compile(
+            "\"(.*)\""
+    );
+
+    private static final Pattern ISSUE_PATTERN = Pattern.compile(
+    "(https://(?:github\\.com/.+?/issues/\\d+|issues\\.redhat\\.com/browse/\\w+-\\d+))"
+    );
+
+
+    public void analyzeRepository(String repoOwner, String repoName, List<String> branches, String baseOutputFileName) throws IOException {
+        GitHub github = GitHub.connect();
+        GHRepository repo = github.getRepository(repoOwner + "/" + repoName);
+
+        for (String branch : branches) {
+            GHTree tree = repo.getTreeRecursive(branch, 1);
+            List<DisabledTest> disabledTests = new ArrayList<>();
+            Map<String, DisabledTestsModuleStats> moduleStats = new HashMap<>();
+
+            for (GHTreeEntry entry : tree.getTree()) {
+                String filePath = entry.getPath();
+                if (entry.getPath().contains("/test/") && filePath.endsWith(".java")) {
+                    GHContent fileContent = repo.getFileContent(filePath, branch);
+                    disabledTests.addAll(extractDisabledTests(fileContent, moduleStats));
+                }
+            }
+
+            BranchAnalysisResult result = new BranchAnalysisResult(branch, disabledTests);
+            String testListFile = getStatsOrTestFileName(baseOutputFileName, branch, false);
+            new ObjectMapper().writerWithDefaultPrettyPrinter().writeValue(new File(testListFile), result);
+
+            String statsListFile = getStatsOrTestFileName(baseOutputFileName, branch, true);
+            new ObjectMapper().writerWithDefaultPrettyPrinter().writeValue(new File(statsListFile), moduleStats);
+        }
+    }
+
+    private List<DisabledTest> extractDisabledTests(GHContent ghContent,
+                                                    Map<String, DisabledTestsModuleStats> moduleStats) throws IOException {
+
+        String fileUrl = ghContent.getHtmlUrl();
+        String fileContent = ghContent.getContent();
+
+        List<DisabledTest> disabledTests = new ArrayList<>();
+        String[] lines = fileContent.split("\n");
+
+        String previousLine = "";
+        String currentClass = "UnknownClass";
+        String currentTestMethod = null;
+        List<String> annotationTypes = new ArrayList<>();
+        List<String> reasons = new ArrayList<>();
+        List<String> issueLinks = new ArrayList<>();
+        boolean insideDisabledBlock = false;
+
+        for (String currentLine : lines) {
+            currentLine = currentLine.trim();
+
+            Matcher classMatcher = CLASS_DECLARATION_PATTERN.matcher(currentLine);
+            if (classMatcher.find()) {
+                currentClass = classMatcher.group(1);
+            }
+
+            Matcher testMethodMatcher = TEST_METHOD_PATTERN.matcher(currentLine);
+            if (testMethodMatcher.find()) {
+                currentTestMethod = testMethodMatcher.group(1);
+            }
+
+            Matcher disabledMatcher = DISABLED_ANNOTATION_PATTERN.matcher(currentLine);
+            if (disabledMatcher.find()) {
+                String reason = null;
+                String issueLink = null;
+                insideDisabledBlock = true;
+                String annotationType = disabledMatcher.group(1);
+
+                String annotationContent = disabledMatcher.group(2);
+                if (annotationContent != null) {
+                    Matcher reasonMatcher = REASON_PATTERN.matcher(annotationContent);
+
+                    if (reasonMatcher.find()) {
+                        reason = reasonMatcher.group(1);
+                    }
+
+                    if (reason == null) {
+                        Matcher explicitReasonmatcher = EXPLICIT_REASON_PATTERN.matcher(annotationContent);
+                        if (explicitReasonmatcher.find()) {
+                            reason = explicitReasonmatcher.group(1);
+                        }
+                    }
+                    issueLink = extractIssueLink(annotationContent);
+                }
+
+                if (issueLink == null && previousLine.startsWith("//")) {
+                    issueLink = extractIssueLink(previousLine);
+                }
+
+                if (issueLink == null && currentLine.startsWith("//")) {
+                    issueLink = extractIssueLink(currentLine);
+                }
+
+                if (reason == null) {
+                    reason = getDisablingReasonComment(previousLine);
+                }
+
+                if (reason == null) {
+                    reason = getDisablingReasonComment(currentLine);
+                }
+
+                annotationTypes.add(annotationType);
+                reasons.add(reason);
+                issueLinks.add(issueLink);
+            }
+
+            if (insideDisabledBlock && (testMethodMatcher.lookingAt() || (classMatcher.lookingAt()))) {
+                for (int i = 0; i < annotationTypes.size(); i++) {
+                    disabledTests.add(new DisabledTest(
+                            currentTestMethod != null ? currentTestMethod : "All methods",
+                            currentClass,
+                            annotationTypes.get(i),
+                            reasons.get(i),
+                            issueLinks.get(i),
+                            fileUrl,
+                            isGitHubIssueClosed(issueLinks.get(i))
+                    ));
+
+                    String moduleName = extractModuleName(ghContent.getPath());
+                    moduleStats.putIfAbsent(moduleName, new DisabledTestsModuleStats());
+                    moduleStats.get(moduleName).incrementAnnotation(annotationTypes.get(i));
+                }
+
+                annotationTypes.clear();
+                reasons.clear();
+                issueLinks.clear();
+                insideDisabledBlock = false;
+            }
+            previousLine = currentLine;
+        }
+        return disabledTests;
+    }
+
+    private String extractIssueLink(String text) {
+        Matcher issueMatcher = ISSUE_PATTERN.matcher(text);
+        return issueMatcher.find() ? issueMatcher.group(1) : null;
+    }
+
+    private String getDisablingReasonComment(String line) {
+        if (line.contains("//")) {
+            return line.substring(line.indexOf("//") + 2).trim();
+        }
+        return null;
+    }
+
+    private boolean isGitHubIssueClosed(String issueLink) {
+        if (issueLink != null && issueLink.contains("github.com")) {
+            try {
+                String[] parts = issueLink.split("/");
+                String repo = parts[parts.length - 4] + "/" + parts[parts.length - 3];
+                int issueNumber = Integer.parseInt(parts[parts.length - 1]);
+
+                GitHub github = GitHub.connect();
+                GHIssue issue = github.getRepository(repo).getIssue(issueNumber);
+                return issue.getState() == GHIssueState.CLOSED;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private String extractModuleName(String filePath) {
+        return filePath.substring(0, filePath.indexOf("/src"));
+    }
+
+    private String getStatsOrTestFileName(String fileName, String branchName, boolean isStats) {
+        String statsSuffix = isStats ? "-stats" : "";
+        return fileName.replaceFirst("(\\.json)?$", "-" + branchName + statsSuffix + ".json");
+    }
+}

--- a/disabled-tests-inspector/src/main/java/io/quarkus/ts/DisabledTestsModuleStats.java
+++ b/disabled-tests-inspector/src/main/java/io/quarkus/ts/DisabledTestsModuleStats.java
@@ -1,0 +1,16 @@
+package io.quarkus.ts;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DisabledTestsModuleStats {
+
+    @JsonAnyGetter
+    private final Map<String, Integer> annotationCounts = new HashMap<>();
+
+    public void incrementAnnotation(String annotation) {
+        annotationCounts.put(annotation, annotationCounts.getOrDefault(annotation, 0) + 1);
+    }
+}

--- a/disabled-tests-inspector/src/main/java/io/quarkus/ts/GitHubAnalysisResource.java
+++ b/disabled-tests-inspector/src/main/java/io/quarkus/ts/GitHubAnalysisResource.java
@@ -1,0 +1,33 @@
+package io.quarkus.ts;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class GitHubAnalysisResource {
+
+    private static final Logger LOG = Logger.getLogger(GitHubAnalysisResource.class);
+
+    @Inject
+    DisabledTestAnalyserService analyserService;
+
+    public void startAnalysis() {
+        String repoOwner = System.getProperty("repoOwner", "org");
+        String repoName = System.getProperty("repoName", "repo-name");
+        String branches = System.getProperty("branches", "main");
+        String baseOutputFileName = System.getProperty("baseOutputFileName", "disabled-tests-report.json");
+
+        try {
+            LOG.info("Starting analysis for " + repoOwner + "/" + repoName + " on branches: " + branches);
+            analyserService.analyzeRepository(repoOwner, repoName, Arrays.asList(branches.split(",")), baseOutputFileName);
+            LOG.info("Analysis finished, see reports in created JSON files.");
+        } catch (IOException e) {
+            LOG.error("Error creating YAML file: ", e);
+        }
+    }
+}

--- a/disabled-tests-inspector/src/main/java/io/quarkus/ts/Main.java
+++ b/disabled-tests-inspector/src/main/java/io/quarkus/ts/Main.java
@@ -1,0 +1,25 @@
+package io.quarkus.ts;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.QuarkusApplication;
+import io.quarkus.runtime.annotations.QuarkusMain;
+import jakarta.inject.Inject;
+
+
+@QuarkusMain
+public class Main {
+    public static void main(String... args) {
+        Quarkus.run(AnalyserApp.class, args);
+    }
+
+    public static class AnalyserApp implements QuarkusApplication {
+        @Inject
+        GitHubAnalysisResource gitHubAnalysisResource;
+
+        @Override
+        public int run(String... args) {
+            gitHubAnalysisResource.startAnalysis();
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
Introduce a tool that analyzes Java test code in a GitHub repository, identifying disabled tests and categorizing them by annotation type and module. It generates a JSON report summarizing the findings.

- Scans Java test files for disabled test annotations
- Extracts reasons and issue links from annotations and comments
- Categorizes disabled tests per module
- Generates structured JSON reports
-  GitHub Personal Access Token is required

Example run with archived reports: https://github.com/gtroitsk/quarkus-utilities/actions/runs/13618718030