### PR TITLE
Reduce log size by adding --batch-mode and --no-transfer-progress

### DIFF
--- a/artifact-version-diff/pom.xml
+++ b/artifact-version-diff/pom.xml
@@ -14,10 +14,10 @@
         <version.junit>5.10.2</version.junit>
         <version.org.apache.maven.maven-artifact>3.9.6</version.org.apache.maven.maven-artifact>
         <version.org.yaml.snakeyaml>2.2</version.org.yaml.snakeyaml>
-        <version.org.apache.maven.plugins>3.12.1</version.org.apache.maven.plugins>
+        <version.org.apache.maven.plugins>3.14.0</version.org.apache.maven.plugins>
         <version.exec-maven-plugin>3.2.0</version.exec-maven-plugin>
         <version.jackson-dataformat-yaml>2.17.0</version.jackson-dataformat-yaml>
-        <version.maven-surefire-plugin>3.2.5</version.maven-surefire-plugin>
+        <version.maven-surefire-plugin>3.5.2</version.maven-surefire-plugin>
         <version.maven-model>3.9.8</version.maven-model>
     </properties>
 

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/PrepareOperation.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/PrepareOperation.java
@@ -46,10 +46,10 @@ public class PrepareOperation {
         executeProcess(gitCloneQuarkus, "Failed to clone Quarkus repository", tmpDirectory);
 
         LOG.info("Executing mvn versions:compare-dependencies");
-        List<String> mvnVersionsExecute = new ArrayList<>(Arrays.asList("mvn", "versions:compare-dependencies"));
+        List<String> mvnVersionsExecute = new ArrayList<>(Arrays.asList("mvn", "--batch-mode", "--no-transfer-progress", "versions:compare-dependencies"));
         mvnVersionsExecute.addAll(prepareMavenProperties());
         Path quarkusRepoDirectory = Paths.get(tmpDirectory.toAbsolutePath().toString(), "quarkus");
-        executeProcess(mvnVersionsExecute, "Failed to add remote origin", quarkusRepoDirectory);
+        executeProcess(mvnVersionsExecute, "Error when executing versions:compare-dependencies plugin", quarkusRepoDirectory);
 
         return quarkusRepoDirectory;
     }
@@ -62,7 +62,7 @@ public class PrepareOperation {
                     .directory(path.toFile())
                     .start();
             StringBuilder output = new StringBuilder();
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            try (BufferedReader reader = process.inputReader()) {
                 String line;
                 while ((line = reader.readLine()) != null) {
                     output.append(line).append("\n");
@@ -91,6 +91,10 @@ public class PrepareOperation {
         extraProperties.add("-DremotePom=" + remotePom);
 
         extraProperties.add("-DreportOutputFile=" + VERSION_PLUGIN_OUTPUT_FILE_NAME);
+        extraProperties.add("-DreportMode=false");
+
+        // This turn off maven INFO logs and show only ERROR logs
+        extraProperties.add("--quiet");
 
         return extraProperties;
     }


### PR DESCRIPTION
I spot that on some machine run out of memory/space when running version plugin. Looking at log I see so much progress and download artifact logs. This should reduce it and remove the memory problem as the all log is stored in memory.

The update need to be done on runners to make sure they not run out of memory

If you want to see that this is "passing" on Jenkins ping me on slack.