### PR TITLE
Add posibility to check disabled tests in quarkus-startstop

### DIFF
--- a/disabled-tests-inspector/src/main/java/io/quarkus/qe/disabled/tests/inspector/DisabledTestAnalyserService.java
+++ b/disabled-tests-inspector/src/main/java/io/quarkus/qe/disabled/tests/inspector/DisabledTestAnalyserService.java
@@ -72,7 +72,7 @@ public class DisabledTestAnalyserService {
 
             for (GHTreeEntry entry : tree.getTree()) {
                 String filePath = entry.getPath();
-                if (entry.getPath().contains("/test/") && filePath.endsWith(".java")) {
+                if ((entry.getPath().contains("/test/") || entry.getPath().contains("testsuite/")) && filePath.endsWith(".java")) {
                     GHContent testClassContent = repo.getFileContent(filePath, branch);
                     TestClassData data = new TestClassData(
                             testClassContent.getHtmlUrl(),


### PR DESCRIPTION
I run it with all of our TSs/FW except extension-combination and found this one issue when running it with [quarkus-startstop](https://github.com/quarkus-qe/quarkus-startstop/tree/main)

The repo have different structure where all test are stored.