### PR TITLE
Add tool to analyze how many tests we run and how many are skipped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store
+/.idea/encodings.xml

--- a/README.md
+++ b/README.md
@@ -56,3 +56,85 @@ Or you can run it manually as described below.
   - These allowed artifacts config file needs to be stored in `src/main/resources` and should have format of `<quarkus_version>_allowed_artifacts.yaml` (e.g `3.8_allowed_artifacts.yaml`), where `_allowed_artifacts.yaml` is must have to work.
   - Testing with RHBQ example (version 3.8.3 vs 3.8.3.redhat-00002):
     - `mvn clean test -Dmaven.repo.local=<path_to_maven_local_repository> -Dquarkus.platform.bom=com.redhat.quarkus.platform:quarkus-bom:3.8.3.redhat-00002 -Dquarkus.repo.tag=3.8.3`
+
+### test-stats-analyzer
+
+Tool that allows to analyze how many tests are run for given Java git project.
+Unlikely tools that use static analysis, this tool transform given project so that test methods and JUnit 5 callback methods have empty bodies.
+This way, when tests are run, we can only collect statistics without executing any verification.
+The downside to this approach is that it takes considerable time to generate the stats.
+Advantage to this approach is that static approach cannot reliably analysis following scenarios:
+
+- how many times is method invoked for a parametrized test value source
+- dynamic test execution conditions written in Java (e.g. disable on Podman, disable on FIPS and RHBQ and so on)
+
+This tool gives overall statistics for executed and skipped tests, you can analyse the disabled tests with the 'disabled-tests-inspector' tool placed also in this project.
+
+#### Prerequisites
+
+You need to have installed JDK 21 or higher and Maven 3.9.6 or higher.
+
+#### How to use it
+
+Use the `test-stats-analyzer/generate-stats.sh` script to generate statistics.
+If you have this project built locally as well as the project for which you want to generate statistics, you can execute `./test-stats-analyzer/generate-stats.sh -d "$PWD" -f ~/sources/quarkus-test-suite`.
+This is the most efficient (quickest) way to generate statistics, however it will modify your project and requires that both projects are built.
+Usually, you will want to generate statistics from ephemeral project directory.
+For example, if you want to generate statistics for JVM mode, native mode, Kubernetes in JVM mode, OpenShift in JVM mode and OpenShift in native for Quarkus QE Test Suite branches 3.15, 3.20 and main, you will do:
+
+```
+wget -q https://raw.githubusercontent.com/quarkus-qe/quarkus-utilities/refs/heads/main/test-stats-analyzer/generate-stats.sh
+chmod +x generate-stats.sh
+./generate-stats.sh -b '3.15,3.20,main' -c 'jvm-mode,native-mode,openshift,kubernetes,openshift+native-mode'
+```
+
+You may want to take it easy (e.g. just one branch and one mode) in order to wait shorter.
+
+Following command options are supported:
+
+| Option | Description                                                                                                | Default value                                        |
+|--------|------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
+| -c     | Modes: 'jvm-mode', 'native-mode', 'openshift', 'kubernetes' as well as any combination of previous values. | jvm-mode                                             |
+| -b     | Target project tested branches.                                                                            | main                                                 |
+| -t     | Target project URL (AKA: URL to project for which you want to generate statistics).                        | https://github.com/quarkus-qe/quarkus-test-suite.git |
+| -f     | Target project directory. If specified, the Target project URL will be ignored                             |                                                      |
+| -d     | Quarkus Utilities project directory. If specified, the Recipe project URL will be ignored.                 |                                                      |
+| -u     | Quarkus Utilities project URL.                                                                             | https://github.com/quarkus-qe/quarkus-utilities.git  |
+| -s     | Quarkus Utilities project branch.                                                                          | main                                                 |
+| -a     | Additional Maven command arguments.                                                                        |                                                      |
+| -r     | Working directory. The main purpose of this directory is to store results.                                 | temporary directory                                  |
+
+For projects other than Quarkus QE Test Suite and Quarkus QE Test Framework, dry run may or may not work depending on JUnit extensions you use.
+Meaning - you would have to tweak the OpenRewrite recipe to remove some additional annotations specific for your project so that code unnecessary for the analysis is not executed.
+
+Please note that if the target project build requires some dependencies not available locally or in configured Maven repositories (like `3.23.999-SNAPSHOT`), you have 2 options.
+Either build the missing dependencies so that they are available, or enhance the `generate-stats.sh` script to recognize supported alternatives.
+For example, for `3.20` branch we currently use `3.20.1` and for `3.15` branch we currently use `3.15.5`, which is done automatically for you.
+
+#### Example result
+
+The `generate-stats.sh` generates `generated_test_stats.xml` into the working directory which has the following format:
+
+```xml
+<report>
+  <project-url>https://github.com/quarkus-qe/quarkus-test-suite.git</project-url>
+  <project-git-branches>main</project-git-branches>
+  <combinations>
+   <combination>
+     <command-arguments></command-arguments>
+     <git-branch>main</git-branch>
+     <modules>
+       <module>
+         <path>./websockets/websocket-next/target/failsafe-reports/failsafe-summary.xml</path>
+         <name>Quarkus QE TS: Websocket Next</name>
+         <completed>24</completed>
+         <skipped>1</skipped>
+       </module>
+     </modules>
+     <completed>2294</completed>
+     <skipped>51</skipped>
+     <summary>Total number of executed tests is 2294 while 51 tests were skipped for combination 'jvm-mode', git branch 'main'</summary>
+   </combination>
+  </combinations>
+</report>
+```

--- a/test-stats-analyzer/generate-stats.sh
+++ b/test-stats-analyzer/generate-stats.sh
@@ -1,0 +1,238 @@
+add_to_report() {
+  echo "$1" >> generated_test_stats
+}
+
+translate_combination_to_mvn_args() {
+  local result=''
+
+  # it is not intuitive that when you run 'mvn clean verify -Dnative' or '-Dopenshift'
+  # on Quarkus QE Test Framework, the 'examples' profile, which is active by default is disabled
+  # so let's activate it as well
+  if [[ -f pom.xml ]] && grep -q "github.com:quarkus-qe/quarkus-test-framework.git" pom.xml; then
+    result="-Pframework,examples"
+  else
+    result="-Dexclude.quarkus.cli.tests=no"
+  fi
+
+  local combination=$1
+  # do nothing for 'jvm-mode' as it is not necessary
+  if [[ "$combination" == *"native-mode"* ]]; then
+    result="$result -Dnative -Dall-modules"
+  fi
+  if [[ "$combination" == *"openshift"* ]]; then
+    result="$result -Dopenshift -Dall-modules"
+  fi
+  if [[ "$combination" == *"kubernetes"* ]]; then
+    result="$result -Dkubernetes -Dall-modules"
+  fi
+  echo "$result"
+}
+
+print_aggregated_failsafe_summaries() {
+   local command_mvn_args="$1"
+   local git_branch="$2"
+   local combination="$3"
+   parse_xml () { local IFS=\> ; read -d \< E C ;}
+   local completed=0
+   local skipped=0
+   add_to_report "   <combination>"
+   if [[ -z $(echo $command_mvn_args | xargs) ]]; then
+     add_to_report "     <command-arguments></command-arguments>"
+   else
+     add_to_report "     <command-arguments>$command_mvn_args</command-arguments>"
+   fi
+   add_to_report "     <git-branch>$git_branch</git-branch>"
+   add_to_report "     <modules>"
+   for report_file_path in `find . -name 'failsafe-summary.xml'`
+   do
+      add_to_report "      <module>"
+      add_to_report "        <path>$report_file_path</path>"
+      
+      # Extract project name from pom.xml (3 levels up from target/failsafe-reports/)
+      local pom_path=$(dirname $(dirname $(dirname "$report_file_path")))/pom.xml
+      if [[ -f "$pom_path" ]]; then
+        local project_name=$(grep -m1 '<name>' "$pom_path" | sed 's/.*<name>\(.*\)<\/name>.*/\1/')
+        if [[ -n "$project_name" ]]; then
+          add_to_report "        <name>$project_name</name>"
+        fi
+      fi
+      while parse_xml; do
+        if [[ $E = completed ]]; then
+          add_to_report "        <completed>$C</completed>"
+          (( completed=completed+C ))
+        fi
+        if [[ $E = skipped ]]; then
+          add_to_report "        <skipped>$C</skipped>"
+          (( skipped=skipped+C ))
+        fi
+        if [[ $E = errors ]] && [[ $C != 0 ]]; then
+          echo "There was $C errors during the test run, exiting stats generation"
+          exit -1
+        fi
+	    done < $report_file_path
+	    add_to_report "      </module>"
+   done
+   add_to_report "     </modules>"
+   local end_message="Total number of executed tests is $completed while $skipped tests were skipped for combination '$combination', git branch '$git_branch'"
+   add_to_report "     <completed>$completed</completed>"
+   add_to_report "     <skipped>$skipped</skipped>"
+   add_to_report "     <summary>$end_message</summary>"
+   add_to_report "   </combination>"
+   echo "- $end_message"
+}
+
+generate_stats_for_branch() {
+    local target_dir=$1
+    local target_branch=$2
+    local mvn_args=$3
+    local recipe_dir=$4
+    local dont_build=$5
+    local combinations=$6
+
+    quarkus_version_arg=''
+    if [[ ${dont_build} == "false" ]]; then
+
+      # some branches like Quarkus QE Test Suite 3.15 and 3.20 requires respective snapshots like 3.20.999-SNAPSHOT
+      # that may or may not be available locally and since Quarkus version is probably irrelevant, let's avoid failure
+      # it could be an issue if some later 3.20.x releases added dependencies or classes that 3.20.1 doesn't support
+      if [[ ${target_branch} == "3.20" ]]; then
+        quarkus_version_arg='-Dquarkus.platform.version=3.20.1'
+        mvn_args="$mvn_args $quarkus_version_arg"
+      fi
+      if [[ ${target_branch} == "3.15" ]]; then
+        quarkus_version_arg='-Dquarkus.platform.version=3.15.5'
+        mvn_args="$mvn_args $quarkus_version_arg"
+      fi
+
+      git reset --hard
+      git checkout $target_branch
+      echo "Build project without running tests"
+      # this is done because OpenRewrite acts differently when the project is built
+      # and it can result in some parsing errors when we don't build the project
+      mvn clean install -DskipTests -DskipITs -Dcheckstyle.skip $quarkus_version_arg
+    fi
+
+    # copy 'rewrite.yml' to project for which we want stats
+    local target_project_root_recipe_location="$target_dir/rewrite.yml"
+    local recipe_project_root_recipe_location="$recipe_dir/test-stats-analyzer/rewrite.yml"
+    echo "Copying recipe file '$recipe_project_root_recipe_location' to '$target_project_root_recipe_location'"
+    cp $recipe_project_root_recipe_location $target_project_root_recipe_location
+
+    # run openrewrite recipe
+    echo "Applying OpenRewrite recipe, this should make all tests methods and JUnit callback methods empty in order to avoid unnecessary test execution"
+    mvn -U org.openrewrite.maven:rewrite-maven-plugin:runNoFork -Drewrite.activeRecipes=io.quarkus.qe.PrepareDryRun -Drewrite.recipeArtifactCoordinates='io.quarkus.qe:test-stats-analyzer:1.0-SNAPSHOT' $quarkus_version_arg -DskipMavenParsing=true --errors
+
+    if [[ $combinations == *","* ]]; then
+      IFS=',' read -r -a combinations_array <<< "$combinations"
+    else
+      combinations_array=("$combinations")
+    fi
+
+    for combination in "${combinations_array[@]}"
+    do
+      enhanced_mvn_args="$mvn_args $(translate_combination_to_mvn_args $combination)"
+
+      # run tests for the target project (surefire, failsafe, native, openshift and possibly podman / docker / windows)
+      # note: ATM actual 'dry-run' implemented in JUnit 5 doesn't count properly parametrized tests etc. so we don't trust it
+      echo "Performing dry-run using command 'mvn clean verify -Dquarkus.build.skip=true -Dcheckstyle.skip $enhanced_mvn_args' on the target project"
+      mvn clean verify -Dquarkus.build.skip=true -Dcheckstyle.skip $enhanced_mvn_args
+
+      # collect information about executed tests and print them
+      print_aggregated_failsafe_summaries "$enhanced_mvn_args" "$target_branch" "$combination"
+    done
+}
+
+# project that generate stats, it includes this script
+RECIPE_PROJECT_BRANCH='main'
+RECIPE_PROJECT_URL='https://github.com/quarkus-qe/quarkus-utilities.git'
+RECIPE_PROJECT_DIRECTORY=''
+
+# project for which we want stats
+TARGET_PROJECT_DIRECTORY=''
+TARGET_PROJECT_URL='https://github.com/quarkus-qe/quarkus-test-suite.git'
+BRANCHES_TO_TEST='main'
+
+# arguments with which we run tests and have direct impact on which tests are run, e.g. '-Dopenshift' or '-Dnative'
+EXTRA_MAVEN_ARGS=''
+
+# possible combinations (JVM mode, native mode, OpenShift, Kubernetes)
+COMBINATIONS='jvm-mode'
+
+# where we store generated stats
+WORKING_DIRECTORY=''
+
+while getopts b:u:d:f:t:s:a:r:c: opt
+do
+    case "${opt}" in
+        s) RECIPE_PROJECT_BRANCH=${OPTARG};;
+        u) RECIPE_PROJECT_URL=${OPTARG};;
+        d) RECIPE_PROJECT_DIRECTORY=${OPTARG};;
+        f) TARGET_PROJECT_DIRECTORY=${OPTARG};;
+        t) TARGET_PROJECT_URL=${OPTARG};;
+        b) BRANCHES_TO_TEST=${OPTARG};;
+        a) EXTRA_MAVEN_ARGS=${OPTARG};;
+        r) WORKING_DIRECTORY=${OPTARG};;
+        c) COMBINATIONS=${OPTARG};;
+    esac
+done
+
+# build this project so that GAV with the recipe is resolved by OpenRewrite maven plugin
+if [ -z "${RECIPE_PROJECT_DIRECTORY}" ]; then
+    RECIPE_PROJECT_DIRECTORY=$(mktemp -d)
+    echo "Building recipe project '$RECIPE_PROJECT_URL' branch '$RECIPE_PROJECT_BRANCH' in directory '$RECIPE_PROJECT_DIRECTORY"
+    PREVIOUS_DIR="$PWD"
+    cd $RECIPE_PROJECT_DIRECTORY
+    git clone --depth=1 $RECIPE_PROJECT_URL -b $RECIPE_PROJECT_BRANCH .
+    cd test-stats-analyzer
+    mvn clean install -DskipTests -DskipITs
+    echo "Project 'io.quarkus.qe:test-stats-analyzer:1.0-SNAPSHOT' has been installed to local Maven repository"
+    cd $PREVIOUS_DIR
+fi
+
+# prepare project for which we require stats
+if [ -z "${TARGET_PROJECT_DIRECTORY}" ]; then
+    SKIP_BUILD="false"
+    TARGET_PROJECT_DIRECTORY=$(mktemp -d)
+    cd $TARGET_PROJECT_DIRECTORY
+    echo "Cloning project $TARGET_PROJECT_URL into directory $TARGET_PROJECT_DIRECTORY"
+    git clone $TARGET_PROJECT_URL .
+    git fetch origin
+else
+    SKIP_BUILD="true"
+    cd $TARGET_PROJECT_DIRECTORY
+fi
+
+if [ -z "${WORKING_DIRECTORY}" ]; then
+    WORKING_DIRECTORY=$(mktemp -d)
+fi
+echo "Results will be stored in directory $WORKING_DIRECTORY"
+
+if [[ $BRANCHES_TO_TEST == *","* ]]; then
+  # multiple git branches to analyze
+  IFS=',' read -r -a BRANCHES_TO_TEST_ARRAY <<< "$BRANCHES_TO_TEST"
+else
+  # only one git branch to analyze
+  BRANCHES_TO_TEST_ARRAY=("$BRANCHES_TO_TEST")
+fi
+
+rm -f generated_test_stats
+add_to_report "<report>"
+if [[ "$SKIP_BUILD" == "true" ]]; then
+  add_to_report "  <project-directory>$TARGET_PROJECT_DIRECTORY</project-directory>"
+else
+  add_to_report "  <project-url>$TARGET_PROJECT_URL</project-url>"
+fi
+add_to_report "  <project-git-branches>$BRANCHES_TO_TEST</project-git-branches>"
+add_to_report "  <combinations>"
+for BRANCH_TO_TEST in "${BRANCHES_TO_TEST_ARRAY[@]}"
+do
+  echo "branch $BRANCH_TO_TEST"
+  generate_stats_for_branch "$TARGET_PROJECT_DIRECTORY" "$BRANCH_TO_TEST" "$EXTRA_MAVEN_ARGS" "$RECIPE_PROJECT_DIRECTORY" "$SKIP_BUILD" "$COMBINATIONS"
+done
+add_to_report "  </combinations>"
+add_to_report "</report>"
+
+# HINT: file 'generated_test_stats' intentionally doesn't have 'xml' extension at first,
+# because during 'Quarkus QE TS: Parent' build some plugins (like 'xml-format:xml-format') may validate it and fail
+cp $PWD/generated_test_stats $WORKING_DIRECTORY/generated_test_stats.xml
+echo "Complete report has been generated to '$WORKING_DIRECTORY/generated_test_stats.xml' file"

--- a/test-stats-analyzer/pom.xml
+++ b/test-stats-analyzer/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.quarkus.qe</groupId>
+    <artifactId>test-stats-analyzer</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <rewrite-recipe-bom.version>3.4.0</rewrite-recipe-bom.version>
+        <junit5.version>5.12.2</junit5.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.openrewrite.recipe</groupId>
+                <artifactId>rewrite-recipe-bom</artifactId>
+                <version>${rewrite-recipe-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit5.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java-21</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- required for TestExecutionListener used to generate summary -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+        </dependency>
+        <!-- dependencies for the recipe verification -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test-stats-analyzer/rewrite.yml
+++ b/test-stats-analyzer/rewrite.yml
@@ -1,0 +1,19 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.qe.PrepareDryRun
+recipeList:
+  - io.quarkus.qe.test.stats.analyzer.recipe.MakeCallbacksAndTestsEmpty
+  - org.openrewrite.java.RemoveAnnotation:
+      annotationPattern: '@io.quarkus.test.scenarios.OpenShiftScenario'
+  - org.openrewrite.java.RemoveAnnotation:
+      annotationPattern: '@io.quarkus.test.scenarios.QuarkusScenario'
+  - org.openrewrite.java.RemoveAnnotation:
+      annotationPattern: '@io.quarkus.test.scenarios.KubernetesScenario'
+  - org.openrewrite.java.RemoveAnnotation:
+      annotationPattern: '@io.quarkus.test.junit.QuarkusTest'
+  - org.openrewrite.java.RemoveAnnotation:
+      annotationPattern: '@io.quarkus.test.junit.QuarkusIntegrationTest'
+  - org.openrewrite.java.RemoveAnnotation:
+      annotationPattern: '@org.junit.jupiter.api.extension.ExtendWith(io.vertx.junit5.VertxExtension.class)'
+  - org.openrewrite.java.RemoveAnnotation:
+      annotationPattern: '@jakarta.inject.Inject'

--- a/test-stats-analyzer/src/main/java/io/quarkus/qe/test/stats/analyzer/recipe/MakeCallbacksAndTestsEmpty.java
+++ b/test-stats-analyzer/src/main/java/io/quarkus/qe/test/stats/analyzer/recipe/MakeCallbacksAndTestsEmpty.java
@@ -1,0 +1,86 @@
+package io.quarkus.qe.test.stats.analyzer.recipe;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.Recipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaPrinter;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+
+import java.util.List;
+import java.util.Set;
+
+public final class MakeCallbacksAndTestsEmpty extends Recipe {
+
+    public MakeCallbacksAndTestsEmpty() {
+        super();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Prepare dry run";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Makes all JUnit test methods and callbacks empty so that we can only detect which tests are run without executing them.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return MakeMethodBodyEmptyVisitor.INSTANCE;
+    }
+
+    private static final class MakeMethodBodyEmptyVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private static final Set<String> METHOD_ANNOTATIONS = Set.of("org.junit.jupiter.api.Test",
+                "org.junit.jupiter.params.ParameterizedTest", "org.junit.jupiter.api.BeforeEach",
+                "org.junit.jupiter.api.AfterEach", "org.junit.jupiter.api.BeforeAll",
+                "org.junit.jupiter.api.AfterAll", "org.junit.jupiter.api.RepeatedTest",
+                "io.quarkus.test.scenarios.TestQuarkusCli");
+        private static final UsesTypeImpl[] TEST_CLASS_VISITOR = METHOD_ANNOTATIONS.stream()
+                .map(UsesTypeImpl::new).toArray(UsesTypeImpl[]::new);
+        private static final MakeMethodBodyEmptyVisitor INSTANCE = new MakeMethodBodyEmptyVisitor();
+
+        @Override
+        public boolean isAcceptable(SourceFile sourceFile, ExecutionContext executionContext) {
+            for (UsesTypeImpl usesType : TEST_CLASS_VISITOR) {
+                if (usesType.isAcceptable(sourceFile, executionContext)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
+            boolean isTestableOrCallback = method.getLeadingAnnotations().stream()
+                    .anyMatch(a -> METHOD_ANNOTATIONS.stream().anyMatch(fullName -> fullName.contains(a.getSimpleName())));
+            J.MethodDeclaration visitedMethod = super.visitMethodDeclaration(method, executionContext);
+            if (isTestableOrCallback && method.getBody() != null && !method.getBody().getStatements().isEmpty()) {
+                visitedMethod = visitedMethod.withBody(J.Block.createEmptyBlock());
+                var removeMethodParameters = method.getParameters().stream()
+                        .map(s -> {
+                            PrintOutputCapture<Integer> outputCapture = new PrintOutputCapture<>(0);
+                            (new JavaPrinter<Integer>()).visit(s, outputCapture);
+                            return outputCapture.getOut();
+                        })
+                        .anyMatch(s -> s.contains("Vertx") || s.contains("OpenShiftClient")
+                                || s.contains("QuarkusVersionAwareCliClient"));
+                if (removeMethodParameters) {
+                    // in theory this could be an issue if we use Vert.x extension with parametrized test, but we don't
+                    visitedMethod = visitedMethod.withParameters(List.of());
+                }
+            }
+            return visitedMethod;
+        }
+    }
+
+    private static final class UsesTypeImpl extends UsesType<ExecutionContext> {
+        private UsesTypeImpl(String fullyQualifiedType) {
+            super(fullyQualifiedType, true);
+        }
+    }
+}

--- a/test-stats-analyzer/src/test/java/io/quarkus/qe/test/stats/analyzer/MakeCallbacksAndTestsEmptyTest.java
+++ b/test-stats-analyzer/src/test/java/io/quarkus/qe/test/stats/analyzer/MakeCallbacksAndTestsEmptyTest.java
@@ -1,0 +1,227 @@
+package io.quarkus.qe.test.stats.analyzer;
+
+import io.quarkus.qe.test.stats.analyzer.recipe.MakeCallbacksAndTestsEmpty;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class MakeCallbacksAndTestsEmptyTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+                .recipe(new MakeCallbacksAndTestsEmpty())
+                .typeValidationOptions(TypeValidation.all());
+    }
+
+    @Test
+    void verifyTestMethodBlockIsEmpty() {
+        //language=java
+        rewriteRun(java(
+                """
+                package io.quarkus.qe.test.stats.analyzer;
+
+                import org.junit.jupiter.api.Test;
+
+                public class MyTest {
+                    @Test
+                    public void getUserName() {
+                        int a = 0;
+                    }
+                }
+                """,
+                """
+                package io.quarkus.qe.test.stats.analyzer;
+
+                import org.junit.jupiter.api.Test;
+
+                public class MyTest {
+                    @Test
+                    public void getUserName(){}
+                }
+                """));
+    }
+
+    @Test
+    void verifyParametrizedTestMethodBlockIsEmpty() {
+        //language=java
+        rewriteRun(java(
+                """
+                package io.quarkus.qe.test.stats.analyzer;
+
+                import org.junit.jupiter.params.ParameterizedTest;
+                import org.junit.jupiter.params.provider.MethodSource;
+
+                public class MyTest {
+                    
+                    @MethodSource("srcMethod")
+                    @ParameterizedTest
+                    public void getUserName(final int idx) {
+                        int a = 0;
+                    }
+                    
+                }
+                """,
+                """
+                package io.quarkus.qe.test.stats.analyzer;
+
+                import org.junit.jupiter.params.ParameterizedTest;
+                import org.junit.jupiter.params.provider.MethodSource;
+
+                public class MyTest {
+                    
+                    @MethodSource("srcMethod")
+                    @ParameterizedTest
+                    public void getUserName(final int idx){}
+                    
+                }
+                """));
+    }
+
+    @Test
+    void verifyCallbackMethodsAreEmpty() {
+        //language=java
+        rewriteRun(java(
+                """
+                package io.quarkus.qe;
+                
+                import org.junit.jupiter.api.AfterAll;
+                import org.junit.jupiter.api.AfterEach;
+                import org.junit.jupiter.api.BeforeAll;
+                import org.junit.jupiter.api.BeforeEach;
+                import org.junit.jupiter.api.Test;
+                
+                public class CallbacksTest {
+                
+                    @Test
+                    public void testCallbacks() {
+                        int a = 1;
+                    }
+                
+                    @BeforeEach
+                    public void before() {
+                        int b = 0;
+                    }
+                
+                    @AfterEach
+                    public void after() {
+                        int c = 0;
+                    }
+                
+                    @BeforeAll
+                    public static void beforeAll() {
+                        int d = 0;
+                    }
+                
+                    @AfterAll
+                    public static void afterAll() {
+                        int e = 0;
+                    }
+                
+                }""",
+                """
+                package io.quarkus.qe;
+                
+                import org.junit.jupiter.api.AfterAll;
+                import org.junit.jupiter.api.AfterEach;
+                import org.junit.jupiter.api.BeforeAll;
+                import org.junit.jupiter.api.BeforeEach;
+                import org.junit.jupiter.api.Test;
+                
+                public class CallbacksTest {
+                
+                    @Test
+                    public void testCallbacks(){}
+                
+                    @BeforeEach
+                    public void before(){}
+                
+                    @AfterEach
+                    public void after(){}
+                
+                    @BeforeAll
+                    public static void beforeAll(){}
+                
+                    @AfterAll
+                    public static void afterAll(){}
+                
+                }"""));
+    }
+
+    @Test
+    void verifyVertxTestParametersAreRemoved() {
+        //language=java
+        rewriteRun(java(
+                """
+                package io.quarkus.qe;
+                
+                import org.junit.jupiter.api.AfterAll;
+                import org.junit.jupiter.api.AfterEach;
+                import org.junit.jupiter.api.BeforeAll;
+                import org.junit.jupiter.api.BeforeEach;
+                import org.junit.jupiter.api.Test;
+                
+                public class VertxParamsTest {
+                
+                    public record Vertx() {}
+                
+                    @Test
+                    public void testVertx(Vertx vertx) {
+                        int a = 1;
+                    }
+                
+                }""",
+                """
+                package io.quarkus.qe;
+                
+                import org.junit.jupiter.api.AfterAll;
+                import org.junit.jupiter.api.AfterEach;
+                import org.junit.jupiter.api.BeforeAll;
+                import org.junit.jupiter.api.BeforeEach;
+                import org.junit.jupiter.api.Test;
+                
+                public class VertxParamsTest {
+                
+                    public record Vertx() {}
+                
+                    @Test
+                    public void testVertx(){}
+                
+                }"""));
+    }
+
+    @Test
+    void verifyRepeatedTestMethodBlockIsEmpty() {
+        //language=java
+        rewriteRun(java(
+                """
+                package io.quarkus.qe.test.stats.analyzer;
+
+                import org.junit.jupiter.api.RepeatedTest;
+
+                public class MyTest {
+                    
+                    @RepeatedTest
+                    public void getUserName(final int idx) {
+                        int a = 0;
+                    }
+                    
+                }
+                """,
+                """
+                package io.quarkus.qe.test.stats.analyzer;
+
+                import org.junit.jupiter.api.RepeatedTest;
+
+                public class MyTest {
+                    
+                    @RepeatedTest
+                    public void getUserName(final int idx){}
+                    
+                }
+                """));
+    }
+}


### PR DESCRIPTION
You can read the README to understand why and when is this tool useful. The baseline is that we need to compare how many tests we run (and how many tests were skipped and for which reasons) among Quarkus releases. Questions like "How many tests did we add for Quarkus 3.20" and "How many tests we disbled for Quarkus 3.20" can be answered by this tool reliably for individual supported configurations (baremetal, OpenShfit, Kubernetes, JVM, native and depending on where you use the tool, for which architecture and OS).