### PR TITLE
Configuration for RHBQ/IBQ 3.27.3, adjustment to the codebase

### DIFF
--- a/artifact-version-diff/.gitignore
+++ b/artifact-version-diff/.gitignore
@@ -17,3 +17,6 @@ target/
 outputDiff.html
 outputDiffDetailed.html
 platformBomComparison.html
+
+#Bob
+.bob

--- a/artifact-version-diff/AGENTS.md
+++ b/artifact-version-diff/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS.md
+
+This file provides guidance to agents when working with code in this repository.
+
+## Project Overview
+
+This is a Java Maven utility for comparing artifact versions between upstream Quarkus and Red Hat Build of Quarkus (RHBQ). The tool analyzes dependency differences across the Quarkus ecosystem and generates detailed HTML reports highlighting version discrepancies.
+
+**Main Technologies:**
+- Java 17
+- Maven 3.x
+- Jackson (YAML processing)
+- Maven Artifact API
+- JUnit 5 (testing)
+
+**Core Functionality:**
+1. Clones the Quarkus repository at a specific tag
+2. Executes `mvn versions:compare-dependencies` to identify version differences
+3. Compares platform BOMs between upstream and RHBQ
+4. Generates HTML reports with color-coded version differences
+5. Validates differences against allowed artifact lists
+
+## Building and Running
+
+### Prerequisites
+- Java 17+
+- Maven 3.x
+- Git (for cloning Quarkus repository)
+
+### Build the Project
+```bash
+mvn clean install
+```
+
+### Run the Main Application
+```bash
+mvn exec:java
+```
+
+**Required System Properties:**
+- `quarkus.platform.bom`: RHBQ platform BOM coordinates (e.g., `com.redhat.quarkus.platform:quarkus-bom:3.27.3.redhat-00003`)
+- `quarkus.repo.tag`: Upstream Quarkus version/tag (e.g., `3.27.3`)
+
+**Optional System Properties:**
+- `maven.repo.local`: Custom Maven local repository path
+- `quarkus-version`: Version prefix for loading allowed artifacts file (e.g., `3.27`)
+
+### Example Usage via Shell Script
+```bash
+./prod_vs_upstream.sh 3.27.3.redhat-00003 /path/to/maven/repo
+```
+
+### Run Tests
+```bash
+mvn test
+```
+
+## Key Components
+
+### Main Entry Point
+- **Main.java**: Orchestrates the comparison workflow by calling PrepareOperation, GenerateVersionDiffReport, and GeneratePomComparison
+
+### Core Classes
+- **PrepareOperation**: Clones Quarkus repository and executes Maven versions plugin
+- **GenerateVersionDiffReport**: Analyzes version differences and generates HTML reports
+- **GeneratePomComparison**: Compares platform BOMs and identifies missing/extra artifacts
+- **PomComparator**: Parses and compares Maven POM files
+- **AllowedArtifacts**: Manages YAML configuration for allowed version differences
+- **Artifact**: Data model for artifact version information
+
+### Output Files
+The tool generates three HTML reports:
+1. **outputDiff.html**: Simple overview of version differences
+2. **outputDiffDetailed.html**: Detailed report with affected locations
+3. **platformBomComparison.html**: BOM comparison showing missing/extra artifacts
+
+### Allowed Artifacts Configuration
+YAML files in `src/main/resources/` define allowed version differences:
+- Format: `{version}_allowed_artifacts.yaml` (e.g., `3.27_allowed_artifacts.yaml`)
+- Structure:
+  - `allowed-artifacts`: List of artifacts with permitted RHBQ versions
+  - `allowed-missing-artifacts-bom-comparison`: Artifacts allowed to be missing in RHBQ BOM
+  - `allowed-extra-artifacts-bom-comparison`: Artifacts allowed to be extra in RHBQ BOM
+
+## Development Conventions
+
+### Version Comparison Logic
+- **Major/Minor differences**: Highlighted in red (older) or yellow (newer)
+- **Patch differences**: Tracked but not highlighted
+- **Allowed artifacts**: Must match patterns in YAML configuration (supports wildcards with `*`)
+
+### Test Strategy
+- Tests validate that version differences are within acceptable bounds
+- Major/minor version differences cause test failures
+- Patch-only differences mark builds as unstable
+- BOM comparison tests ensure all differences are in allowed lists
+
+### Code Organization
+- Main source: `src/main/java/io/quarkus/qe/`
+- Resources: `src/main/resources/` (allowed artifacts YAML files)
+- Tests: `src/test/java/io/quarkus/qe/`
+
+### Error Handling
+- Uses RuntimeException for critical failures
+- Validates required system properties at startup
+- Provides detailed error messages with context
+
+### Logging
+- Uses `java.util.logging.Logger` for all logging
+- Log levels: INFO for progress, detailed error messages on failures
+
+## Working with This Codebase
+
+When modifying this tool:
+1. **Adding new allowed artifacts**: Update or create version-specific YAML files in `src/main/resources/`
+2. **Changing comparison logic**: Focus on `GenerateVersionDiffReport.differencesInVersions()`
+3. **Modifying HTML output**: Update HTML templates in `HTML_BASE_START` and `HTML_BASE_END` constants
+4. **Adding new validations**: Extend test cases in `DiffReportTest.java`
+5. **Handling complex versions**: See `setComplicatedArtifactVersion()` for special version parsing logic
+
+### Important Notes
+- The tool creates temporary directories for Quarkus repository clones
+- Maven versions plugin output files are named `depDiffs.txt`
+- Regex patterns in allowed artifacts use `.*` instead of `*` for matching
+- Version comparison uses `DefaultArtifactVersion` from Maven Artifact API

--- a/artifact-version-diff/README.md
+++ b/artifact-version-diff/README.md
@@ -1,0 +1,205 @@
+# Artifact Version Diff Tool
+
+A Java Maven utility for comparing artifact versions between upstream Quarkus and Red Hat Build of Quarkus (RHBQ). This tool analyzes dependency differences across the Quarkus ecosystem and generates detailed HTML reports highlighting version discrepancies.
+
+## Features
+
+- 🔍 Automated comparison of artifact versions between upstream Quarkus and RHBQ
+- 📊 Three detailed HTML reports with color-coded differences
+- ✅ Configurable allowed version differences via YAML files
+- 🧪 Automated testing to validate version differences
+- 🎯 Platform BOM comparison to identify missing/extra artifacts
+
+## Prerequisites
+
+- Java 17 or higher
+- Maven 3.x
+- Git (for cloning Quarkus repository)
+
+## Installation
+
+Clone the repository and build the project:
+
+```bash
+git clone <repository-url>
+cd artifact-version-diff
+mvn clean install
+```
+
+## Usage
+
+### Using Maven Exec Plugin
+
+```bash
+mvn exec:java \
+  -Dquarkus.platform.bom=com.redhat.quarkus.platform:quarkus-bom:3.27.3.redhat-00003 \
+  -Dquarkus.repo.tag=3.27.3 \
+  -Dmaven.repo.local=/path/to/maven/repo \
+  -Dquarkus-version=3.27
+```
+
+### Using the Shell Script
+
+A convenience script is provided for easier execution:
+
+```bash
+./prod_vs_upstream.sh <RHBQ_VERSION> <MAVEN_LOCAL_REPO>
+```
+
+Example:
+```bash
+./prod_vs_upstream.sh 3.27.3.redhat-00003 /path/to/maven/repo
+```
+
+### System Properties
+
+| Property | Required | Description | Example |
+|----------|----------|-------------|---------|
+| `quarkus.platform.bom` | Yes | RHBQ platform BOM coordinates | `com.redhat.quarkus.platform:quarkus-bom:3.27.3.redhat-00003` |
+| `quarkus.repo.tag` | Yes | Upstream Quarkus version/tag | `3.27.3` |
+| `maven.repo.local` | No | Custom Maven local repository path | `/path/to/maven/repo` |
+| `quarkus-version` | No | Version prefix for loading allowed artifacts file | `3.27` |
+
+## Output Files
+
+The tool generates three HTML reports in the project root directory:
+
+### 1. outputDiff.html
+Simple overview showing:
+- Artifact names
+- Version differences (upstream → RHBQ)
+- Color coding: 🟡 Yellow (newer), 🔴 Red (older)
+
+### 2. outputDiffDetailed.html
+Detailed report including:
+- All information from simple report
+- Locations of affected extensions/modules
+- Full dependency tree context
+
+### 3. platformBomComparison.html
+Platform BOM comparison showing:
+- Missing artifacts in RHBQ BOM
+- Extra artifacts in RHBQ BOM
+- Validation against allowed lists
+
+## Configuration
+
+### Allowed Artifacts
+
+Version differences can be whitelisted using YAML configuration files in `src/main/resources/`:
+
+**File naming convention:** `{version}_allowed_artifacts.yaml`
+
+Example: `3.27_allowed_artifacts.yaml`
+
+```yaml
+allowed-artifacts:
+  - artifact: 'com.aayushatharva.brotli4j:brotli4j'
+    allowed-rhbq-versions:
+      - 1.14.0.redhat-00001
+      - 1.15.0.redhat-00001
+  - artifact: 'net.java.dev.jna:jna-platform'
+    allowed-rhbq-versions:
+      - 5.8.0
+
+allowed-missing-artifacts-bom-comparison:
+  - io.quarkus:quarkus-rest-client-mutiny
+
+allowed-extra-artifacts-bom-comparison:
+  - com.aayushatharva.brotli4j:native-linux-ppc64le
+  - io.netty:netty-transport-native-epoll-ppcle
+```
+
+**Wildcard Support:** Artifact patterns support wildcards using `*`:
+```yaml
+- artifact: 'io.quarkus:*'
+  allowed-rhbq-versions:
+    - 3.27.3.redhat-00003
+```
+
+## Testing
+
+Run the test suite:
+
+```bash
+mvn test
+```
+
+### Test Behavior
+
+- ✅ **Pass**: All version differences are within allowed bounds
+- ❌ **Fail**: Major or minor version differences detected
+- ⚠️ **Unstable**: Only patch version differences detected
+
+## How It Works
+
+1. **Clone Repository**: Clones the upstream Quarkus repository at the specified tag
+2. **Execute Maven Plugin**: Runs `mvn versions:compare-dependencies` to generate version comparison files
+3. **Parse Results**: Analyzes the generated `depDiffs.txt` files across the repository
+4. **Compare BOMs**: Downloads and compares platform BOMs between upstream and RHBQ
+5. **Validate**: Checks differences against allowed artifacts configuration
+6. **Generate Reports**: Creates three HTML reports with color-coded results
+
+## Project Structure
+
+```
+artifact-version-diff/
+├── src/
+│   ├── main/
+│   │   ├── java/io/quarkus/qe/
+│   │   │   ├── Main.java                      # Entry point
+│   │   │   ├── PrepareOperation.java          # Repository cloning & Maven execution
+│   │   │   ├── GenerateVersionDiffReport.java # Version comparison & HTML generation
+│   │   │   ├── GeneratePomComparison.java     # BOM comparison
+│   │   │   ├── PomComparator.java             # POM parsing & comparison
+│   │   │   ├── AllowedArtifacts.java          # YAML configuration handling
+│   │   │   └── Artifact.java                  # Artifact data model
+│   │   └── resources/
+│   │       └── *_allowed_artifacts.yaml       # Version-specific configurations
+│   └── test/
+│       └── java/io/quarkus/qe/
+│           └── DiffReportTest.java            # Test suite
+├── pom.xml
+├── prod_vs_upstream.sh                        # Convenience script
+└── README.md
+```
+
+## Development
+
+### Adding New Allowed Artifacts
+
+1. Create or update the version-specific YAML file in `src/main/resources/`
+2. Add artifact patterns and allowed versions
+3. Run tests to validate configuration
+
+### Modifying Comparison Logic
+
+The main comparison logic is in `GenerateVersionDiffReport.differencesInVersions()`. This method:
+- Compares major and minor versions
+- Applies color coding for HTML output
+- Validates against allowed artifacts
+
+### Handling Complex Versions
+
+Some artifacts have complex version schemes (e.g., `23.1.2.0-3-redhat-00001`). The `setComplicatedArtifactVersion()` method handles special parsing for these cases.
+
+## Troubleshooting
+
+### Common Issues
+
+**Issue:** `The quarkus.platform.bom property wasn't set`
+- **Solution:** Ensure you provide the `-Dquarkus.platform.bom` system property
+
+**Issue:** `Failed to clone Quarkus repository`
+- **Solution:** Check your internet connection and Git configuration
+
+**Issue:** `Error when loading allowed file`
+- **Solution:** Verify the YAML file exists and matches the naming convention
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests for new functionality
+5. Submit a pull request

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/AllowedArtifacts.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/AllowedArtifacts.java
@@ -70,5 +70,13 @@ public class AllowedArtifacts {
         public void setRhbqVersions(List<String> rhbqVersions) {
             this.rhbqVersions = rhbqVersions;
         }
+
+        @Override
+        public String toString() {
+            return "AllowedArtifact{" +
+                    "artifact='" + artifact + '\'' +
+                    ", rhbqVersions=" + rhbqVersions +
+                    '}';
+        }
     }
 }

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/GenerateVersionDiffReport.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/GenerateVersionDiffReport.java
@@ -263,13 +263,13 @@ public class GenerateVersionDiffReport {
             isAllowedWithDifferentVersion(false, artifact, versions[1]);
             return "";
         } else if (versionComparison < 0) {
-            setMajorMinorPatch(true);
+            setMajorMinorPatch(true, artifact);
             return "newer";
         } else if (versionComparison > 0) {
-            setMajorMinorPatch(true);
+            setMajorMinorPatch(true, artifact);
             return "older";
         } else {
-            setMajorMinorPatch(false);
+            setMajorMinorPatch(false, artifact);
             return "";
         }
     }
@@ -294,7 +294,7 @@ public class GenerateVersionDiffReport {
      */
     public void isAllowedWithDifferentVersion(boolean majorMinor, String artifact, String downstreamVersion) {
         if (!isArtifactAllowed(artifact)) {
-            setMajorMinorPatch(majorMinor);
+            setMajorMinorPatch(majorMinor, artifact);
             return;
         }
 
@@ -306,7 +306,7 @@ public class GenerateVersionDiffReport {
             }
         }
         if (!versionContainsAllowed) {
-            setMajorMinorPatch(majorMinor);
+            setMajorMinorPatch(majorMinor, artifact);
         }
     }
 
@@ -350,7 +350,8 @@ public class GenerateVersionDiffReport {
         return new ArrayList<>();
     }
 
-    public void setMajorMinorPatch(boolean majorMinor) {
+    public void setMajorMinorPatch(boolean majorMinor, String problematicArtifact) {
+        LOG.info("Unexpected version difference, problematic artifact: " + problematicArtifact);
         if (majorMinor) {
             majorMinorVersionDiffer = true;
         } else {

--- a/artifact-version-diff/src/main/java/io/quarkus/qe/PrepareOperation.java
+++ b/artifact-version-diff/src/main/java/io/quarkus/qe/PrepareOperation.java
@@ -42,7 +42,7 @@ public class PrepareOperation {
         LOG.info("Cloning Quarkus repository");
         String branch = Objects.requireNonNull(System.getProperty("quarkus.repo.tag"), "The quarkus.repo.tag property wasn't set.");
         List<String> gitCloneQuarkus = new ArrayList<>(
-                Arrays.asList("git", "clone", "--single-branch", "--branch", branch, "https://github.com/quarkusio/quarkus.git"));
+                Arrays.asList("git", "clone", "--depth",  "1", "--single-branch", "--branch", branch, "https://github.com/quarkusio/quarkus.git"));
         executeProcess(gitCloneQuarkus, "Failed to clone Quarkus repository", tmpDirectory);
 
         LOG.info("Executing mvn versions:compare-dependencies");
@@ -55,6 +55,7 @@ public class PrepareOperation {
     }
 
     public static void executeProcess(List<String> command, String errorMsg, Path path) {
+        LOG.info("Executing " + command + ", " + path);
         ProcessBuilder builder = new ProcessBuilder(command);
         builder.directory(path.toFile());
         try {

--- a/artifact-version-diff/src/main/resources/3.27_allowed_artifacts.yaml
+++ b/artifact-version-diff/src/main/resources/3.27_allowed_artifacts.yaml
@@ -1,0 +1,51 @@
+allowed-artifacts-version-comparison:
+  # CVE fixes in 3.27.3 were applied on prod level
+  - artifact:
+      io.vertx:vertx-*
+    allowed-rhbq-versions:
+      - 4.5.26.redhat-00001
+      - 4.5.26
+  - artifact:
+      io.smallrye.reactive:smallrye-mutiny-vertx-*
+    allowed-rhbq-versions:
+      - 3.21.6.redhat-00001
+      - 3.21.6
+  - artifact:
+      io.smallrye.reactive:vertx-mutiny-generator
+    allowed-rhbq-versions:
+      - 3.21.6.redhat-00001
+  - artifact:
+      io.netty:netty-*
+    allowed-rhbq-versions:
+      - 4.1.132.Final-redhat-00001
+      - 4.1.132.Final
+  - artifact:
+      io.netty:netty-tcnative*
+    allowed-rhbq-versions:
+      - 2.0.75.Final-redhat-00002
+      - 2.0.75.Final
+  - artifact:
+      org.codehaus.plexus:plexus-utils
+    allowed-rhbq-versions:
+      - 3.6.0.redhat-00001
+  - artifact:
+      com.fasterxml.jackson*:*
+    allowed-rhbq-versions:
+      - 2.21.2.redhat-00001
+      - 2.21.2
+  - artifact:
+      com.fasterxml.jackson.core:jackson-annotations
+    allowed-rhbq-versions:
+      - 2.21.0.redhat-00002
+  - artifact:
+      io.agroal:agroal-*
+    allowed-rhbq-versions:
+      - 2.8.1.redhat-00001
+
+allowed-extra-artifacts-bom-comparison:
+  - io.netty:netty-transport-native-epoll-aarch
+  - io.netty:netty-transport-native-epoll-ppcle
+  - io.netty:netty-transport-native-epoll-s390x
+  - io.netty:netty-transport-native-unix-common-ppcle
+  - io.netty:netty-transport-native-unix-common-s390x
+  - com.fasterxml.jackson.datatype:jackson-datatype-hibernate7

--- a/artifact-version-diff/src/test/java/io/quarkus/qe/DiffReportTest.java
+++ b/artifact-version-diff/src/test/java/io/quarkus/qe/DiffReportTest.java
@@ -7,19 +7,29 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.logging.Logger;
 
 
 public class DiffReportTest {
 
+    private static final Logger LOG = Logger.getLogger(DiffReportTest.class.getName());
     public static AllowedArtifacts allowedArtifactsFile;
 
     @BeforeAll
     public static void loadAllowedArtifact() {
         allowedArtifactsFile = PrepareOperation.loadAllowedArtifactFile();
+        if (allowedArtifactsFile == null) {
+            LOG.info("No allowed_artifacts file found");
+        }
     }
 
     @Test
-    public void checkNoArtifactHave() throws IOException {
+    public void checkForDifferentArtifactsVersions() throws IOException {
+        // Hint to reuse data from previous execution and just focus on versions comparison
+//        Path quarkusRepoDirectory = java.nio.file.Paths.get("/var/folders/mc/cbr401q11wx9xn8fxl5ttx6w0000gn/T/artifact-comparison-EMvNe/quarkus");
+//        PrepareOperation.upstreamVersion = "3.27.3";
+//        PrepareOperation.rhbqVersion = "3.27.3.redhat-00003";
+
         Path quarkusRepoDirectory = PrepareOperation.prepareVersionPluginOutput();
 
         GenerateVersionDiffReport report = new GenerateVersionDiffReport(quarkusRepoDirectory, allowedArtifactsFile);


### PR DESCRIPTION
Configuration for RHBQ/IBQ 3.27.3

Adjustment to the codebase
 * Provide details about problematic artifact in setMajorMinorPatch method
 * depth 1 added to the git clone command
 * Message about no allowed_artifacts file case
 * Hint to reuse data from previous execution and just focus on versions comparison
 
Adding README.md and AGENTS.md generated by Bob
* (this is optional, depends on the review)