### PR TITLE
Bump bootstrap and jquery versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,7 @@ target/
 !**/src/test/**/target/
 
 ### IntelliJ IDEA ###
-.idea/modules.xml
-.idea/jarRepositories.xml
-.idea/compiler.xml
-.idea/libraries/
+.idea
 *.iws
 *.iml
 *.ipr

--- a/diff-utils/create_colorful_diff.sh
+++ b/diff-utils/create_colorful_diff.sh
@@ -24,11 +24,11 @@ cat <<EOF > $FILENAME
 	<link rel="stylesheet" type="text/css" href="https://cemerick.github.io/jsdifflib/diffview.css"><script type="text/javascript" src="https://cemerick.github.io/jsdifflib/diffview.js"></script><script type="text/javascript" src="https://cemerick.github.io/jsdifflib/difflib.js"></script>
 
 	<!-- Bootstrap CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
   <!-- jQuery-->
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.7.1.slim.min.js"></script>
   <!-- Bootstrap JS -->
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js"></script>
 
 <style type="text/css">
   body {

--- a/diff-utils/create_colorful_diff.sh
+++ b/diff-utils/create_colorful_diff.sh
@@ -28,7 +28,7 @@ cat <<EOF > $FILENAME
   <!-- jQuery-->
   <script src="https://code.jquery.com/jquery-3.7.1.slim.min.js"></script>
   <!-- Bootstrap JS -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js"></script>
 
 <style type="text/css">
   body {


### PR DESCRIPTION
Bump bootstrap and jquery versions

jsdifflib is not in active development, so I looked at alternatives. https://www.npmjs.com/package/diff is the best option for new library, but I didn't find quick way to have side-by-side view. Also http://incaseofstairs.com/jsdiff/ shows inline changes.

Note: I got to https://github.com/kpdecker/jsdiff/issues/198, JsDiff + Diff2HtmlUI could be good candidates if we look into diffs again (e.g. documentation diffs)